### PR TITLE
Module name appears to case sensitive on the server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     Handlebars = require('handlebars'),
-    Hoek = require('Hoek'),
+    Hoek = require('hoek'),
     Localizer = require('./localizer'),
     Path = require('path'),
     internals = {};


### PR DESCRIPTION
Node wouldn't load stapler until Hoek was change to hoek.
