### PR TITLE
BIG-20355: Set last item of array as context

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -397,6 +397,16 @@ internals.loadHelpers = function (context, translations) {
     Handlebars.registerHelper('concat', function (value, otherValue) {
         return new Handlebars.SafeString(value + otherValue);
     })
+
+    /**
+     * Set the last item of an array as context
+     *
+     * @example
+     * {{#last items}} {{title}} {{/last}}
+     */
+    Handlebars.registerHelper('last', function (array, options) {
+        return options.fn(_.last(array));
+    });
 };
 
 /**


### PR DESCRIPTION
Set the last item of an array as context

```
{{#last items}} {{title}} {{/last}}
```

Related PR: https://github.com/bigcommerce/stencil/pull/380

@haubc @mcampa 
