### PR TITLE
Font matcher fix

### DIFF
--- a/helpers/getFontsCollection.js
+++ b/helpers/getFontsCollection.js
@@ -9,7 +9,7 @@ internals.implementation.prototype.register = function(context) {
     var handlebars = this.handlebars;
 
     handlebars.registerHelper('getFontsCollection', function() {
-        var fontKeyFormat = new RegExp(/\w+-font$/),
+        var fontKeyFormat = new RegExp(/\w+(-\w*)*-font$/),
             googleFonts = [],
             linkElements = [];
 


### PR DESCRIPTION
Pretty critical bug, right now the matcher only looks for any word ending in `-font` however a `word` doesn't include `-` so something like: `something-something-font` wont match.

The new matcher fixes this issue.

@haubc @hegrec 
