### PR TITLE
Add command line precompiler

### DIFF
--- a/bin/precompile
+++ b/bin/precompile
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+var Precompiler = require('../lib/precompiler');
+if (process.argv.length < 3) {
+    throw new Error('Must supply a path to an unzipped stencil theme bundle');
+}
+
+new Precompiler(process.argv[2]).precompile();

--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -1,0 +1,136 @@
+var Graph = require('tarjan-graph');
+var Fs = require('fs');
+var Handlebars = require('handlebars');
+var Path = require('path');
+
+/**
+ * A precompiler for faster runtime rendering
+ * @param bundlePath
+ * @constructor
+ */
+function StencilPrecompiler(bundlePath) {
+    this.bundlePath = bundlePath;
+    this.parsedTemplatePath = Path.join(this.bundlePath, 'parsed/templates');
+}
+
+/**
+ * Precompiles templates for speedy runtime rendering
+ */
+StencilPrecompiler.prototype.precompile = function() {
+    checkParsedTemplatesDirectoryExists.call(this);
+    detectCycles.call(this);
+    precompilePartials.call(this);
+};
+
+function checkParsedTemplatesDirectoryExists() {
+    var stat = Fs.statSync(this.parsedTemplatePath);
+
+    if (!stat.isDirectory()) {
+        throw new Error(this.parsedTemplatePath + ' is not a valid directory');
+    }
+}
+
+function detectCycles() {
+    var partialFiles = Fs.readdirSync(this.parsedTemplatePath);
+    var partialRegex = /\{\{>\s*([_|\-|a-zA-Z0-9\/]+)[^{]*?}}/g;
+    var dynamicComponentRegex = /\{\{\s*?dynamicComponent\s*(?:'|")([_|\-|a-zA-Z0-9\/]+)(?:'|").*?}}/g;
+
+    partialFiles.forEach(function(fileName) {
+        var graph = new Graph();
+        var filePath = Path.join(this.parsedTemplatePath, fileName);
+        var dynamicComponents;
+        var fileContent;
+        var match;
+        var matches;
+        var parsedContents;
+        var partial;
+        var partialPath;
+        var prop;
+
+        if (Path.extname(fileName) != '.json') {
+            return;
+        }
+
+        fileContent = Fs.readFileSync(filePath, 'utf8');
+        parsedContents = JSON.parse(fileContent);
+
+        for (prop in parsedContents) {
+            if (parsedContents.hasOwnProperty(prop)) {
+                matches = [];
+                partial = parsedContents[prop];
+                match = partialRegex.exec(partial);
+                while (match !== null) {
+                    partialPath = match[1];
+                    matches.push(partialPath);
+                    match = partialRegex.exec(partial);
+                }
+
+                match = dynamicComponentRegex.exec(partial);
+
+                while (match !== null) {
+                    dynamicComponents = getDynamicComponents.call(this, match[1], parsedContents);
+                    matches.push.apply(matches, dynamicComponents);
+                    match = dynamicComponentRegex.exec(partial);
+
+                }
+
+                graph.add(prop, matches);
+            }
+        }
+
+        if (graph.hasCycle()) {
+            throw new Error('Template includes cycle detected\r\n', graph.getCycles());
+        }
+
+    }.bind(this));
+}
+
+function getDynamicComponents(componentFolder, possibleTemplates) {
+    var output = [];
+    var prop;
+
+    for (prop in possibleTemplates) {
+        if (possibleTemplates.hasOwnProperty(prop)) {
+            if (prop.indexOf(componentFolder) === 0) {
+                output.push(prop);
+            }
+        }
+    }
+
+    return output;
+}
+
+function precompilePartials() {
+    var partialFiles = Fs.readdirSync(this.parsedTemplatePath);
+    var handlebars = Handlebars.create();
+    var options = {
+        preventIndent: true
+    };
+
+    partialFiles.forEach(function(fileName) {
+        var filePath = Path.join(this.parsedTemplatePath, fileName);
+        var precompiledMap = {};
+        var fileContent;
+        var parsedContents;
+        var partial;
+        var prop;
+
+        if (Path.extname(fileName) != '.json') {
+            return;
+        }
+
+        fileContent = Fs.readFileSync(filePath, 'utf8');
+        parsedContents = JSON.parse(fileContent);
+
+        for (prop in parsedContents) {
+            if (parsedContents.hasOwnProperty(prop)) {
+                partial = parsedContents[prop];
+                precompiledMap[prop] = handlebars.precompile(parsedContents[prop], options);
+            }
+        }
+
+        Fs.writeFileSync(filePath, JSON.stringify(precompiledMap), 'utf8');
+    }.bind(this));
+}
+
+module.exports = StencilPrecompiler;

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "handlebars": "^3.0.1",
     "hoek": "^2.12.0",
     "lodash": "^3.6.0",
-    "messageformat": "^0.2.2"
+    "messageformat": "^0.2.2",
+    "tarjan-graph": "^0.3.0"
   },
   "devDependencies": {
     "code": "^1.4.0",
-    "lab": "^5.8.1"
+    "lab": "^5.8.1",
+    "sinon": "^1.17.2"
   }
 }

--- a/test/lib/precompiler.spec.js
+++ b/test/lib/precompiler.spec.js
@@ -1,0 +1,122 @@
+var Code = require('code');
+var Lab = require('lab');
+var Precompiler = require('../../lib/precompiler');
+var Fs = require('fs');
+var _ = require('lodash');
+var Handlebars = require('handlebars');
+var sinon = require('sinon');
+var lab = exports.lab = Lab.script();
+var describe = lab.experiment;
+var expect = Code.expect;
+var it = lab.it;
+
+describe('Paper precompiler', function() {
+    var templateFiles = [
+        'file1.json'
+    ];
+    var fileContents = '{"abc":"Inside abc,{{> bbb}}","bbb":"Inside bbb,{{> ccc}}","ccc":"Inside ccc,{{> abc}}"}';
+    var noCycleFileContents = '{"abc":"Inside abc,{{> bbb}} {{> ccc}}","bbb":"Inside bbb,{{> ccc}}","ccc":"Inside ccc"}';
+    var fsReaddirSyncStub;
+    var fsReadfileSyncStub;
+    var fsStatSyncStub;
+    var fsWriteFileSyncStub;
+
+    lab.beforeEach(function(done) {
+        fsReaddirSyncStub = sinon.stub(Fs, 'readdirSync');
+        fsReadfileSyncStub = sinon.stub(Fs, 'readFileSync');
+        fsStatSyncStub = sinon.stub(Fs, 'statSync');
+        fsWriteFileSyncStub = sinon.stub(Fs, 'writeFileSync');
+
+        done();
+    });
+
+    lab.afterEach(function(done) {
+        fsReaddirSyncStub.restore();
+        fsReadfileSyncStub.restore();
+        fsStatSyncStub.restore();
+        fsWriteFileSyncStub.restore();
+
+        done();
+    });
+
+    it('should throw an error if the bundle directory does not exist', function(done) {
+        var error = null;
+        var precompiler = new Precompiler('/var/tmp/example/fakepath');
+
+        fsStatSyncStub.returns({
+            isDirectory: function() {return false;}
+        });
+
+        try {
+            precompiler.precompile();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).instanceOf(Error);
+
+        done();
+    });
+
+    it('should throw an error if the bundled templates have a cycle', function(done) {
+        var error = null;
+        var precompiler = new Precompiler('/var/tmp/example/fakepath');
+
+        fsStatSyncStub.returns({
+            isDirectory: function() {return true;}
+        });
+        fsReaddirSyncStub.returns(templateFiles);
+        fsReadfileSyncStub.returns(fileContents);
+
+        try {
+            precompiler.precompile();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).instanceOf(Error);
+
+        done();
+    });
+
+    it('should precompile templates', function(done) {
+        var error = null;
+        var handlebars = Handlebars.create();
+        var precompiler = new Precompiler('/var/tmp/example/fakepath');
+        var result;
+
+        var output;
+
+        fsStatSyncStub.returns({
+            isDirectory: function() {return true;}
+        });
+        fsReaddirSyncStub.returns(templateFiles);
+        fsReadfileSyncStub.returns(noCycleFileContents);
+
+
+        try {
+            precompiler.precompile();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).to.be.null();
+
+        result = JSON.parse(fsWriteFileSyncStub.getCall(0).args[1]);
+
+        _.each(result, function (precompiled, path) {
+
+            if (!handlebars.partials[path]) {
+                eval('var template = ' + precompiled);
+                handlebars.partials[path] = handlebars.template(template);
+            }
+        });
+
+        output = handlebars.partials['abc']();
+
+        expect(output).to.equal("Inside abc,Inside bbb,Inside ccc Inside ccc");
+
+        done();
+    });
+});
+


### PR DESCRIPTION
Takes in a folder to the temporary unbundled zip and modifies the json template manifests to be precompiled.

Also does cycle detection with [Tarjan's](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm) to prevent stack overflow when templates are rendered.

@haubc @mickr @mcampa @mattolson 
