### PR TITLE
BIG-24959 - Add webdav support to cdn helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ module.exports = function (assembler) {
     };
 
     /**
-     * Load Partials/Templates 
+     * Load Partials/Templates
      * @param  {Object}   templates
      * @param  {Function} callback
      */
@@ -95,7 +95,7 @@ module.exports = function (assembler) {
      * @return {Object}
      */
     self.loadTemplatesSync = function(templates) {
-        _.each(templates, function (content, fileName) {          
+        _.each(templates, function (content, fileName) {
             self.handlebars.templates[fileName] = self.handlebars.compile(content, self.options);
         });
 
@@ -136,6 +136,16 @@ module.exports = function (assembler) {
 
         if (/^(?:https?:)?\/\//.test(path)) {
             return path;
+        }
+
+        if (path.substr(0, 7) === 'webdav:') {
+            path = path.slice(7, path.length);
+
+            if (path[0] === '/') {
+                path = path.slice(1, path.length);
+            }
+
+            return [cdnUrl, 'content', path].join('/');
         }
 
         if (path[0] !== '/') {

--- a/test/helpers/cdn.js
+++ b/test/helpers/cdn.js
@@ -17,7 +17,7 @@ describe('cdn helper', function() {
             theme_version_id: '123',
             theme_config_id: '3245',
         }
-    }
+    };
 
     it('should render the css cdn url', function(done) {
         expect(c('{{cdn "assets/css/style.css"}}', context))
@@ -67,6 +67,17 @@ describe('cdn helper', function() {
 
         expect(c('{{cdn ""}}', context))
             .to.be.equal('');
+
+        done();
+    });
+
+    it('should return a webDav asset if webdav protocol specified', function(done) {
+
+        expect(c('{{cdn "webdav:img/image.jpg"}}', context))
+            .to.be.equal('https://cdn.bcapp/3dsf74g/content/img/image.jpg');
+
+        expect(c('{{cdn "webdav:/img/image.jpg"}}', context))
+            .to.be.equal('https://cdn.bcapp/3dsf74g/content/img/image.jpg');
 
         done();
     });


### PR DESCRIPTION
Most of the team is out on PTO @davidchin can you take a look at this?
BIG-24959 - Add webdav support to can helper
- Added webdev "protocol" to assetPath, if webdav: is added to the assetPath string, the webdev url will be generated scoped to the content folder.
#### Why

When assets are uploaded to Webdav, they should be placed in the `content` folder and will reside in Swift. The current implementation for the `cdn` generates a url that includes the stencil path, version id, and configuration `{{cdn "assets/js/app.js"}}` converts to `https://cdn.bcapp/3dsf74g/stencil/123/3245/js/app.js`. The changes in this PR will make the cdn helper out a simple cdn url that will point to the content folder on swift if indicated.
#### Example

 Normal `{{cdn "assets/js/app.js"}}` converts to `https://cdn.bcapp/3dsf74g/stencil/123/3245/js/app.js`
WebDav `{{cdn "webdav:img/image.jpg"}}` will generate `https://cdn.bcapp/3dsf74g/content/img/image.jpg`
