### PR TITLE
Add "or" helper to output content if/or

### DIFF
--- a/helpers/any.js
+++ b/helpers/any.js
@@ -13,15 +13,47 @@ internals.implementation = function(handlebars) {
 };
 
 internals.implementation.prototype.register = function(context) {
-    this.handlebars.registerHelper('any', function(collection, options) {
-        var predicate = options.hash,
-            any = _.any(collection, predicate);
+    this.handlebars.registerHelper('any', function() {
 
-        if (any) {
-            return options.fn(this);
+        var args = [],
+            opts,
+            predicate,
+            any;
+
+        // Translate arguments to array safely
+        for (var i = 0; i < arguments.length; i++) {
+            args.push(arguments[i]);
         }
 
-        return options.inverse(this);
+        // Take the last argument (content) out of testing array
+        opts = args.pop();
+        predicate = opts.hash; 
+
+        if (!_.isEmpty(predicate)) {
+            // With options hash, we check the contents of first argument
+            any = _.any(args[0], predicate);
+        } else {
+            // Without options hash, we check all the arguments
+            any = _.any(args, function(arg) {
+                if (_.isArray(arg)) {
+                    return !!arg.length;
+                }
+                // If an empty object is passed, arg is false
+                else if (_.isEmpty(arg) && _.isObject(arg)) {
+                    return false;
+                }
+                // Everything else
+                else {
+                    return !!arg;
+                }
+            });
+        }
+
+        if (any) {
+            return opts.fn(this);
+        }
+
+        return opts.inverse(this);
     });
 };
 

--- a/test/helpers/any.js
+++ b/test/helpers/any.js
@@ -1,0 +1,97 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    return new Paper().loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('any helper (with option hash)', function() {
+    var context = {
+        big: 'big',
+        arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
+    };
+
+    it('should return "big" with matching predicate ', function(done) {
+
+        expect(c('{{#any arrayWithObjs a=1}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#any arrayWithObjs a=2}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#any arrayWithObjs b=1}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+
+        done();
+    });
+
+    it('should return nothing without matching predicate ', function(done) {
+
+        expect(c('{{#any arrayWithObjs b=2}}{{big}}{{/any}}', context))
+            .to.be.equal('');
+
+        expect(c('{{#any arrayWithObjs c=1}}{{big}}{{/any}}', context))
+            .to.be.equal('');
+
+        expect(c('{{#any arrayWithObjs num=2}}{{big}}{{/any}}', context))
+            .to.be.equal('');
+
+        done();
+
+    });
+
+});
+
+
+describe('any helper (with multiple arguments)', function() {
+    var context = {
+        num1: 1,
+        num2: 2,
+        product: {a: 1, b: 2},
+        string: 'yolo',
+        alwaysTrue: true,
+        alwaysFalse: false,
+        emptyArray: [],
+        emptyObject: {},
+        itemArray: [1,2],
+        big: 'big',
+        arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
+    };
+
+    it('should return "big" if at least one arg valid', function(done) {
+
+        expect(c('{{#any arrayWithObjs string}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+      
+        expect(c('{{#any "something test" itemArray}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+      
+        expect(c('{{#any "this is before the other test"}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+      
+        expect(c('{{#any alwaysFalse emptyArray string}}{{big}}{{/any}}', context))
+            .to.be.equal('big');
+      
+        done();
+
+    });
+
+    it('should return "" when no arguments are valid', function(done) {
+
+        expect(c('{{#any emptyArray emptyObject alwaysFalse}}{{big}}{{/any}}', context))
+            .to.be.equal('');
+      
+        expect(c('{{#any "" false}}{{big}}{{/any}}', context))
+            .to.be.equal('');
+      
+        done();
+
+    });
+
+});
+


### PR DESCRIPTION
While working with templates, it's often helpful to be able to output
content if any one of several arguments is valid. (For instance, only
show a product tab if there is warranty info OR shipping info. Only
show social icons wrapper if any one of the icons is present, etc.)

- Add or helper based off the existing "if" helper - content will
  render if any/at least one of the arguments supplied validates
- Add some basic tests to verify the functionality of the or helper