### PR TITLE
Add #all helper for testing multiple conditions

### DIFF
--- a/helpers/all.js
+++ b/helpers/all.js
@@ -1,0 +1,52 @@
+var _ = require('lodash'),
+    internals = {};
+
+/**
+ * Yield block only if all arguments are valid
+ *
+ * @example
+ * {{#all items theme_settings.optionA theme_settings.optionB}} ... {{/all}}
+ */
+
+internals.implementation = function(handlebars) {
+    this.handlebars = handlebars;
+};
+
+internals.implementation.prototype.register = function(context) {
+    this.handlebars.registerHelper('all', function () {
+
+        var args = [], opts, result;
+
+        // Translate arguments to array safely
+        for (var i = 0; i < arguments.length; i++) {
+            args.push(arguments[i]);
+        }
+
+        // Take the last argument (content) out of testing array
+        opts = args.pop();
+
+        // Check if all the arguments are valid / truthy
+        result = _.all(args, function(arg) {
+            if (_.isArray(arg)) {
+                return !!arg.length;
+            }
+            // If an empty object is passed, arg is false
+            else if (_.isEmpty(arg) && _.isObject(arg)) {
+                return false;
+            }
+            // Everything else
+            else {
+                return !!arg;
+            }
+        });
+
+        // If everything was valid, then "all" condition satisfied
+        if (result) {
+            return opts.fn(this);
+        } else {
+            return opts.inverse(this);
+        }
+    });
+};
+
+module.exports = internals.implementation;

--- a/test/helpers/all.js
+++ b/test/helpers/all.js
@@ -1,0 +1,103 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    return new Paper().loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('all helper', function() {
+    var context = {
+        num1: 1,
+        num2: 2,
+        product: {a: 1, b: 2},
+        string: 'yolo',
+        alwaysTrue: true,
+        alwaysFalse: false,
+        emptyArray: [],
+        emptyObject: {},
+        itemArray: [1,2],
+        emptyString: "",
+        big: 'big'
+    };
+
+    it('(with single argument) should behave like if helper', function(done) {
+        expect(c('{{#all 1}}{{big}}{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all 1}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all "x"}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all ""}}big{{/all}}', context))
+            .to.be.equal('');
+
+        expect(c('{{#all 0}}big{{/all}}', context))
+            .to.be.equal('');
+
+        expect(c('{{#all ""}}big{{else}}small{{/all}}', context))
+            .to.be.equal('small');
+
+        expect(c('{{#all 0}}big{{else}}small{{/all}}', context))
+            .to.be.equal('small');
+
+        expect(c('{{#all num2}}big{{else}}small{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all product}}big{{else}}small{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all itemArray}}big{{else}}small{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all string}}big{{else}}small{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all emptyObject}}big{{else}}small{{/all}}', context))
+            .to.be.equal('small');
+
+        done();
+    });
+
+    it('should render "big" if all conditions truthy', function(done) {
+
+        expect(c('{{#all "1" true}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all 1 "1"}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all "text" alwaysTrue}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all alwaysTrue product num1 num2}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all alwaysTrue itemArray string}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        done();
+    });
+
+    it('should render empty if any condition is falsy', function(done) {
+
+        expect(c('{{#all emptyString num1}}big{{/all}}', context))
+            .to.be.equal('');
+
+        expect(c('{{#all true 0 emptyArray alwaysTrue}}big{{/all}}', context))
+            .to.be.equal('');
+
+        expect(c('{{#all true "" alwaysTrue}}big{{/all}}', context))
+            .to.be.equal('');
+
+        done();
+    });
+
+
+});


### PR DESCRIPTION
It's possible with handlebars currently to test against multiple
conditions simply by nesting if loops. However, it becomes difficult
when there are more than just a couple arguments that need to be
nested, and it's not possible to use an else conditional for the event
that one is missing.

- Add an #all helper that can be supplied multiple arguments and will
  render the block so long as they're all "truthy"
- Include some test coverage for the all helper.