### PR TITLE
Make replace helper more sturdy

### DIFF
--- a/helpers/replace.js
+++ b/helpers/replace.js
@@ -6,7 +6,11 @@ internals.implementation = function(handlebars) {
 
 internals.implementation.prototype.register = function(context) {
     this.handlebars.registerHelper('replace', function(needle, haystack, options) {
-        var contains = haystack.indexOf(needle) > -1;
+        var contains = false;
+
+        if (typeof(haystack) === 'string') {
+            contains = haystack.indexOf(needle) > -1;
+        }
 
         // Yield block if true
         if (contains) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/test/helpers/replace.js
+++ b/test/helpers/replace.js
@@ -28,4 +28,12 @@ describe('replace helper', function() {
         done();
     });
 
+    it('should handle undefined values', function(done) {
+        var context = {};
+        expect(c(templates, context))
+            .to.be.equal('');
+
+        done();
+    });
+
 });


### PR DESCRIPTION
### What
Handle undefined haystack values.

### Why
A case came up where a theme was using the helper with an undefined haystack and this caused a 500 error for the pages involved.