### PR TITLE
Lint files and split a helper out to be more appropriate

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,25 @@
+{
+  "ecmaFeatures": {
+    "modules": true
+  },
+  "env": {
+    "node": true,
+  },
+  "globals": {
+
+  },
+  "rules": {
+    "curly": 2,
+    "no-eq-null": 2,
+    "wrap-iife": [
+      2,
+      "any"
+    ],
+    "new-cap": 2,
+    "no-caller": 2,
+    "dot-notation": 0,
+    "no-debugger": 2,
+    "no-undef": 2,
+    "no-unused-vars": 2,
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
   - 0.12
 script:
   - npm install
+  - npm install -g gulp-cli
+  - gulp
   - npm test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,23 @@
+var gulp = require('gulp'),
+    eslint = require('gulp-eslint');
+
+gulp.task('lint', function () {
+    // ESLint ignores files with "node_modules" paths.
+    // So, it's best to have gulp ignore the directory as well.
+    // Also, Be sure to return the stream from the task;
+    // Otherwise, the task may end before the stream has finished.
+    return gulp.src(['**/*.js','!node_modules/**'])
+        // eslint() attaches the lint output to the "eslint" property
+        // of the file object so it can be used by other modules.
+        .pipe(eslint())
+        // eslint.format() outputs the lint results to the console.
+        // Alternatively use eslint.formatEach() (see Docs).
+        .pipe(eslint.format())
+        // To have the process exit with an error code (1) on
+        // lint error, return the stream and pipe to failAfterError last.
+        .pipe(eslint.failAfterError());
+});
+
+gulp.task('default', ['lint'], function () {
+    // This will only run if the lint task is successful...
+});

--- a/helpers/all.js
+++ b/helpers/all.js
@@ -12,7 +12,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function () {
     this.handlebars.registerHelper('all', function () {
 
         var args = [], opts, result;

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -33,6 +33,7 @@ internals.implementation.prototype.register = function() {
             // With options hash, we check the contents of first argument
             any = _.any(args[0], predicate);
         } else {
+            // DEPRECATED: Moved to #or helper
             // Without options hash, we check all the arguments
             any = _.any(args, function(arg) {
                 if (_.isArray(arg)) {

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -12,7 +12,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('any', function() {
 
         var args = [],

--- a/helpers/block.js
+++ b/helpers/block.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     var self = this;
 
     this.handlebars.registerHelper('block', function (name, options) {

--- a/helpers/compare.js
+++ b/helpers/compare.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('compare', function (lvalue, rvalue, options) {
         var operator,
             operators,

--- a/helpers/concat.js
+++ b/helpers/concat.js
@@ -9,7 +9,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     var self = this;
 
     this.handlebars.registerHelper('concat', function (value, otherValue) {

--- a/helpers/contains.js
+++ b/helpers/contains.js
@@ -13,8 +13,8 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
-    this.handlebars.registerHelper('contains', function(value, targetValue) {
+internals.implementation.prototype.register = function() {
+    this.handlebars.registerHelper('contains', function() {
         var args = Array.prototype.slice.call(arguments, 0, -1),
             options = _.last(arguments),
             contained = _.contains.apply(_, args);

--- a/helpers/deprecated.js
+++ b/helpers/deprecated.js
@@ -5,8 +5,8 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
-    this.handlebars.registerHelper('pick', function(object, predicate) {
+internals.implementation.prototype.register = function() {
+    this.handlebars.registerHelper('pick', function() {
         return _.pick.apply(null, arguments);
     });
 
@@ -61,8 +61,7 @@ internals.implementation.prototype.register = function(context) {
      */
     this.handlebars.registerHelper('enumerate', function(start, end, options) {
         var out = '',
-            i = start,
-            iOut;
+            i = start;
 
         for (i; i <= end; i++) {
             out = out + options.fn(i);

--- a/helpers/dynamicComponent.js
+++ b/helpers/dynamicComponent.js
@@ -1,17 +1,14 @@
 var Path = require('path'),
-    _ = require('lodash'),
     internals = {};
 
 internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context, paper) {
+internals.implementation.prototype.register = function() {
     var self = this;
 
     this.handlebars.registerHelper('dynamicComponent', function(path) {
-        var template;
-
         if (!this['partial']) {
             return;
         }

--- a/helpers/for.js
+++ b/helpers/for.js
@@ -5,7 +5,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('for', function(from, to, context, options) {
         var output = '',
             maxIterations = 100;

--- a/helpers/helperMissing.js
+++ b/helpers/helperMissing.js
@@ -2,7 +2,7 @@ var helper = function (handlebars) {
     this.handlebars = handlebars;
 };
 
-helper.prototype.register = function (context) {
+helper.prototype.register = function () {
     this.handlebars.registerHelper('helperMissing', function () {
     	return undefined;
     });

--- a/helpers/if.js
+++ b/helpers/if.js
@@ -5,7 +5,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('if', function (lvalue, operator, rvalue, options) {
         var result;
 

--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -15,7 +15,7 @@ internals.implementation.prototype.register = function(context, paper) {
         paper.inject[key] = value;
     });
 
-    this.handlebars.registerHelper('jsContext', function (options) {
+    this.handlebars.registerHelper('jsContext', function () {
 
         var jsContext = JSON.stringify(JSON.stringify(paper.inject));
 

--- a/helpers/join.js
+++ b/helpers/join.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('join', function(array, separator, options) {
         var config = options.hash || {};
 

--- a/helpers/json.js
+++ b/helpers/json.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('json', function (data) {
         return JSON.stringify(data);
     });

--- a/helpers/limit.js
+++ b/helpers/limit.js
@@ -12,7 +12,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('limit', function(data, limit) {
 
         if (_.isString(data)) {

--- a/helpers/nl2br.js
+++ b/helpers/nl2br.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     var self = this;
     // https://github.com/danharper/Handlebars-Helpers/blob/master/src/helpers.js#L89
     this.handlebars.registerHelper('nl2br', function(text) {

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -1,0 +1,52 @@
+var _ = require('lodash'),
+    internals = {};
+
+/**
+ * Yield block if any object within a collection matches supplied predicate
+ *
+ * @example
+ * {{#or 1 0 0 0 0 0}} ... {{/or}}
+ */
+
+internals.implementation = function(handlebars) {
+    this.handlebars = handlebars;
+};
+
+internals.implementation.prototype.register = function() {
+    this.handlebars.registerHelper('or', function() {
+        var args = [],
+        opts,
+        any;
+
+        // Translate arguments to array safely
+        for (var i = 0; i < arguments.length; i++) {
+            args.push(arguments[i]);
+        }
+
+        // Take the last argument (content) out of testing array
+        opts = args.pop();
+
+        // Without options hash, we check all the arguments
+        any = _.any(args, function(arg) {
+            if (_.isArray(arg)) {
+                return !!arg.length;
+            }
+            // If an empty object is passed, arg is false
+            else if (_.isEmpty(arg) && _.isObject(arg)) {
+                return false;
+            }
+            // Everything else
+            else {
+                return !!arg;
+            }
+        });
+
+        if (any) {
+            return opts.fn(this);
+        }
+
+        return opts.inverse(this);
+    });
+};
+
+module.exports = internals.implementation;

--- a/helpers/pluck.js
+++ b/helpers/pluck.js
@@ -5,7 +5,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('pluck', function(collection, path) {
         return _.pluck(collection, path);
     });

--- a/helpers/pre.js
+++ b/helpers/pre.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     var self = this;
 
     this.handlebars.registerHelper('pre', function (value) {

--- a/helpers/replace.js
+++ b/helpers/replace.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('replace', function(needle, haystack, options) {
         var contains = false;
 

--- a/helpers/snippets.js
+++ b/helpers/snippets.js
@@ -1,13 +1,12 @@
-var _ = require('lodash'),
-    internals = {};
+var internals = {};
 
 internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context, paper) {
+internals.implementation.prototype.register = function() {
 
-    this.handlebars.registerHelper('snippet', function(location, options) {
+    this.handlebars.registerHelper('snippet', function(location) {
         return '<!-- snippet location ' + location + ' -->';
     });
 };

--- a/helpers/toLowerCase.js
+++ b/helpers/toLowerCase.js
@@ -4,7 +4,7 @@ internals.implementation = function(handlebars) {
     this.handlebars = handlebars;
 };
 
-internals.implementation.prototype.register = function(context) {
+internals.implementation.prototype.register = function() {
     this.handlebars.registerHelper('toLowerCase', function(string) {
 
         if (typeof string !== 'string') {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = function (assembler) {
 
                 if (!self.handlebars.templates[path]) {
                     eval('var template = ' + precompiled);
-                    self.handlebars.templates[path] = self.handlebars.template(template);
+                    self.handlebars.templates[path] = self.handlebars.template(template); // eslint-disable-line no-undef
                 }
             });
 
@@ -113,7 +113,7 @@ module.exports = function (assembler) {
                 return callback(error);
             }
             // Make translations available to the helpers
-            self.translate = Localizer(acceptLanguage, translations);
+            self.translate = Localizer.localize(acceptLanguage, translations);
 
             callback();
         });

--- a/lib/localizer.js
+++ b/lib/localizer.js
@@ -9,9 +9,8 @@ var _ = require('lodash'),
  * @param translations
  * @returns {Function}
  */
-module.exports = function (acceptLanguage, translations) {
-    var compiledTranslations,
-        preferredTranslation,
+function localize(acceptLanguage, translations) {
+    var preferredTranslation,
         preferredLangs,
         suitableLang = 'en';
 
@@ -39,7 +38,10 @@ module.exports = function (acceptLanguage, translations) {
 
     // return a translator function
     return internals.getTranslator(suitableLang, preferredTranslation);
-};
+}
+
+module.exports.localize = localize;
+
 
 /**
  * This function will load all of the JSON nested locale files and flatten them
@@ -49,7 +51,6 @@ module.exports = function (acceptLanguage, translations) {
 internals.flattenLocales = function (locales) {
     var output = {};
 
-    var a = new Hoek.Timer();
     _.forOwn(locales, function (localeData, localeName) {
         try {
             output[localeName] = internals.flattenObject(localeData);

--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -16,7 +16,7 @@ function StencilPrecompiler(bundlePath) {
 /**
  * Precompiles templates for speedy runtime rendering
  */
-StencilPrecompiler.prototype.precompile = function() {
+StencilPrecompiler.prototype.precompile = function () {
     checkParsedTemplatesDirectoryExists.call(this);
     detectCycles.call(this);
     precompilePartials.call(this);
@@ -112,7 +112,6 @@ function precompilePartials() {
         var precompiledMap = {};
         var fileContent;
         var parsedContents;
-        var partial;
         var prop;
 
         if (Path.extname(fileName) != '.json') {
@@ -124,7 +123,6 @@ function precompilePartials() {
 
         for (prop in parsedContents) {
             if (parsedContents.hasOwnProperty(prop)) {
-                partial = parsedContents[prop];
                 precompiledMap[prop] = handlebars.precompile(parsedContents[prop], options);
             }
         }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Bigcommerce",
   "license": "BSD-4-Clause",
   "scripts": {
-    "test": "lab -l -t 80"
+    "test": "lab -l -t 90"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
   },
   "devDependencies": {
     "code": "^1.4.0",
+    "eslint": "^2.7.0",
+    "eslint-config-airbnb": "^6.2.0",
+    "eslint-plugin-react": "^4.3.0",
+    "gulp": "^3.9.1",
+    "gulp-eslint": "^2.0.0",
     "lab": "^5.8.1",
     "sinon": "^1.17.2"
   }

--- a/test/helpers/any.js
+++ b/test/helpers/any.js
@@ -49,6 +49,7 @@ describe('any helper (with option hash)', function() {
 
 
 describe('any helper (with multiple arguments)', function() {
+    // DEPRECATED: Moved to #or helper
     var context = {
         num1: 1,
         num2: 2,

--- a/test/helpers/or.js
+++ b/test/helpers/or.js
@@ -1,0 +1,57 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    return new Paper().loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('or helper', function() {
+    var context = {
+        num1: 1,
+        num2: 2,
+        product: {a: 1, b: 2},
+        string: 'yolo',
+        alwaysTrue: true,
+        alwaysFalse: false,
+        emptyArray: [],
+        emptyObject: {},
+        itemArray: [1,2],
+        big: 'big',
+        arrayWithObjs: [{a: 1},{b: 1},{a: 2}]
+    };
+
+    it('should return "big" if at least one arg valid', function(done) {
+        expect(c('{{#or arrayWithObjs string}}{{big}}{{/or}}', context))
+            .to.be.equal('big');
+      
+        expect(c('{{#or "something test" itemArray}}{{big}}{{/or}}', context))
+            .to.be.equal('big');
+      
+        expect(c('{{#or "this is before the other test"}}{{big}}{{/or}}', context))
+            .to.be.equal('big');
+      
+        expect(c('{{#or alwaysFalse emptyArray string}}{{big}}{{/or}}', context))
+            .to.be.equal('big');
+      
+        done();
+
+    });
+
+    it('should return "" when no arguments are valid', function(done) {
+        expect(c('{{#or emptyArray emptyObject alwaysFalse}}{{big}}{{/or}}', context))
+            .to.be.equal('');
+      
+        expect(c('{{#or "" false}}{{big}}{{/or}}', context))
+            .to.be.equal('');
+      
+        done();
+
+    });
+
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 var Code = require('code'),
     Lab = require('lab'),
-    Handlebars = require('handlebars'),
     Paper = require('../index'),
     lab = exports.lab = Lab.script(),
     describe = lab.experiment,
@@ -8,17 +7,6 @@ var Code = require('code'),
     it = lab.it;
 
 describe('loadTheme()', function() {
-    var templates = {
-            'pages/product': '<html>{{> pages/partial}}</html>',
-            'pages/partial': '<p>{{variable}}</p>',
-            'pages/greet': '<h1>{{lang \'good\'}} {{lang \'morning\'}}</h1>',
-            'pages/pre': '{{{pre object}}}',
-        },
-        context = {
-            variable: 'hello world',
-            object: {}
-        };
-
     it('should use the assembler interface to load templates and translations', function(done) {
         var assembler = {
             getTemplates: function(path, processor, callback) {

--- a/test/lib/precompiler.spec.js
+++ b/test/lib/precompiler.spec.js
@@ -108,7 +108,7 @@ describe('Paper precompiler', function() {
 
             if (!handlebars.partials[path]) {
                 eval('var template = ' + precompiled);
-                handlebars.partials[path] = handlebars.template(template);
+                handlebars.partials[path] = handlebars.template(template); // eslint-disable-line no-undef
             }
         });
 


### PR DESCRIPTION
Splitting the #or functionality away from #any so it is easier to document and follow. Retaining #any as is for now for backwards compatibility. Also added gulp linting and fixes for the linted files.


@mickr @mcampa 