### PR TITLE
MERC-616 update customized image dimension preset

### DIFF
--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -8,24 +8,26 @@ var _ = require('lodash'),
 function imageSize(preset, presets) {
 
     // default image size to 'original'
-    var width,
+    var _preset = '_images.' + preset,
+        dimension,
         height,
+        width,
         size = 'original';
 
     if (_.isString(preset)) {
 
-        // If preset is provided by the user
-        if (preset.indexOf('x') > 0) {
+        // If preset is one of the given presets (default preset)
+        if (/^\d+x\d+$/.test(preset)) {
             size = preset;
         }
 
-        // If preset is one of the given presets
-        if (_.isObject(presets[preset])) {
-            width = presets[preset].width || 100;
-            height = presets[preset].height || 100;
+        //If preset is editable by the user
+        if (presets.hasOwnProperty(_preset)) {
+            dimension = presets[_preset];
+            width = _.values(dimension[0])[0] || 100;
+            height = _.values(dimension[1])[0] || 100;
             size = width + 'x' + height;
         }
-
     }
 
     return size;
@@ -37,13 +39,9 @@ internals.implementation = function(handlebars) {
 
 internals.implementation.prototype.register = function(context) {
     this.handlebars.registerHelper('getImage', function (image, preset, defaultImage) {
-        var presets = {},
+        var presets = context.theme_settings,
             size,
             url;
-
-        if (context.theme_settings && context.theme_settings._images) {
-            presets = context.theme_settings._images;
-        }
 
         if (!_.isObject(image)) {
             return _.isString(image) ? image : defaultImage;

--- a/test/helpers/getImage.js
+++ b/test/helpers/getImage.js
@@ -18,16 +18,14 @@ describe('getImage helper', function() {
         },
         logoPreset: 'logo',
         theme_settings: {
-            _images: {
-                logo: {
-                    width: 250,
-                    height: 100
+            "_images.logo" : [
+                {
+                    "Max width": 250
                 },
-                gallery: {
-                    width: 300,
-                    height: 300
+                {
+                    "Max height": 100
                 }
-            }
+            ]
         }
     };
 
@@ -60,8 +58,8 @@ describe('getImage helper', function() {
 
     it('should return logo size for logo preset', function(done) {
 
-        var logoPresets = context.theme_settings._images[context.logoPreset];
-        var logoDimension = logoPresets.width + 'x' + logoPresets.height;
+        var logoPreset = context.theme_settings['_images.logo'];
+        var logoDimension = logoPreset[0]['Max width'] + 'x' + logoPreset[1]['Max height'];
         var expectedPath = context.image.data.replace('{:size}', logoDimension);
 
         expect(c('{{getImage image logoPreset}}', context)).to.be.equal(expectedPath);


### PR DESCRIPTION
update to use the new `_images` presets (in dot notation instead of nested)
see https://github.com/bigcommerce/stencil/pull/797/files for more info