### PR TITLE
Enable support for custom defined CDN endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,17 @@ Paper.prototype.cdnify = function (path) {
             return [cdnUrl, 'content', path].join('/');
         }
 
+        if (this.themeSettings.cdn) {
+            var endpointKey = match[0].substr(0, match[0].length - 1);
+            if (this.themeSettings.cdn.hasOwnProperty(endpointKey)) {
+                if (cdnUrl) {
+                    return [this.themeSettings.cdn[endpointKey].path, path].join('/');
+                }
+
+                return ['/assets/cdn', endpointKey, path].join('/');
+            }
+        }
+
         if (path[0] !== '/') {
             path = '/' + path;
         }

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ Paper.prototype.cdnify = function (path) {
             var endpointKey = match[0].substr(0, match[0].length - 1);
             if (this.themeSettings.cdn.hasOwnProperty(endpointKey)) {
                 if (cdnUrl) {
-                    return [this.themeSettings.cdn[endpointKey].path, path].join('/');
+                    return [this.themeSettings.cdn[endpointKey], path].join('/');
                 }
 
                 return ['/assets/cdn', endpointKey, path].join('/');

--- a/index.js
+++ b/index.js
@@ -157,6 +157,10 @@ Paper.prototype.cdnify = function (path) {
     var sessionId = this.settings['theme_session_id'];
     var protocolMatch = /(.*!?:)/;
 
+    if (path instanceof Handlebars.SafeString) {
+      path = path.string;
+    }
+
     if (!path) {
         return '';
     }

--- a/test/helpers/cdn.js
+++ b/test/helpers/cdn.js
@@ -110,6 +110,17 @@ describe('cdn helper', function () {
         done();
     });
 
+    it('should return a custom CDN asset when using nested helper', function (done) {
+
+        expect(c('{{cdn (concat "customcdn:" "img/image.jpg")}}', context, settings, themeSettings))
+            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
+
+        expect(c('{{cdn (concat "customcdn:" "/img/image.jpg")}}', context, settings, themeSettings))
+            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
+
+        done();
+    });
+
     it('should return a local CDN asset if no cdn url is configured', function (done) {
 
         expect(c('{{cdn "customcdn:img/image.jpg"}}', context, {}, themeSettings))

--- a/test/helpers/cdn.js
+++ b/test/helpers/cdn.js
@@ -6,8 +6,8 @@ var Code = require('code'),
     expect = Code.expect,
     it = lab.it;
 
-function c(template, context, settings) {
-    return new Paper(settings).loadTemplatesSync({template: template}).render('template', context);
+function c(template, context, settings, themeSettings) {
+    return new Paper(settings, themeSettings).loadTemplatesSync({template: template}).render('template', context);
 }
 
 describe('cdn helper', function () {
@@ -17,22 +17,29 @@ describe('cdn helper', function () {
         theme_version_id: '123',
         theme_config_id: '3245',
     };
+    var themeSettings = {
+      cdn: {
+        customcdn: {
+          path: 'https://bigcommerce.customcdn.net'
+        }
+      }
+    };
 
     it('should render the css cdn url', function (done) {
-        expect(c('{{cdn "assets/css/style.css"}}', context, settings))
+        expect(c('{{cdn "assets/css/style.css"}}', context, settings, themeSettings))
             .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/css/style.css');
 
-        expect(c('{{cdn "/assets/css/style.css"}}', context, settings))
+        expect(c('{{cdn "/assets/css/style.css"}}', context, settings, themeSettings))
             .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/css/style.css');
 
         done();
     });
 
     it('should render normal assets cdn url', function (done) {
-        expect(c('{{cdn "assets/js/app.js"}}', context, settings))
+        expect(c('{{cdn "assets/js/app.js"}}', context, settings, themeSettings))
             .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/js/app.js');
 
-        expect(c('{{cdn "assets/img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "assets/img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/img/image.jpg');
 
         done();
@@ -50,13 +57,13 @@ describe('cdn helper', function () {
 
     it('should return the same value if it is a full url', function (done) {
 
-        expect(c('{{cdn "https://example.com/app.js"}}', context, settings))
+        expect(c('{{cdn "https://example.com/app.js"}}', context, settings, themeSettings))
             .to.be.equal('https://example.com/app.js');
 
-        expect(c('{{cdn "http://example.com/app.js"}}', context, settings))
+        expect(c('{{cdn "http://example.com/app.js"}}', context, settings, themeSettings))
             .to.be.equal('http://example.com/app.js');
 
-        expect(c('{{cdn "//example.com/app.js"}}', context, settings))
+        expect(c('{{cdn "//example.com/app.js"}}', context, settings, themeSettings))
             .to.be.equal('//example.com/app.js');
 
         done();
@@ -64,7 +71,7 @@ describe('cdn helper', function () {
 
     it('should return an empty string if no path is provided', function (done) {
 
-        expect(c('{{cdn ""}}', context, settings))
+        expect(c('{{cdn ""}}', context, settings, themeSettings))
             .to.be.equal('');
 
         done();
@@ -72,10 +79,10 @@ describe('cdn helper', function () {
 
     it('should return a webDav asset if webdav protocol specified', function (done) {
 
-        expect(c('{{cdn "webdav:img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "webdav:img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('https://cdn.bcapp/3dsf74g/content/img/image.jpg');
 
-        expect(c('{{cdn "webdav:/img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "webdav:/img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('https://cdn.bcapp/3dsf74g/content/img/image.jpg');
 
         done();
@@ -83,10 +90,43 @@ describe('cdn helper', function () {
 
     it('should not return a webDav asset if webdav protocol is not correct', function (done) {
 
-        expect(c('{{cdn "webbav:img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "webbav:img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('/img/image.jpg');
 
-        expect(c('{{cdn "webbav:/img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "webbav:/img/image.jpg"}}', context, settings, themeSettings))
+            .to.be.equal('/img/image.jpg');
+
+        done();
+    });
+
+    it('should return a custom CDN asset if protocol is configured', function (done) {
+
+        expect(c('{{cdn "customcdn:img/image.jpg"}}', context, settings, themeSettings))
+            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
+
+        expect(c('{{cdn "customcdn:/img/image.jpg"}}', context, settings, themeSettings))
+            .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
+
+        done();
+    });
+
+    it('should return a local CDN asset if no cdn url is configured', function (done) {
+
+        expect(c('{{cdn "customcdn:img/image.jpg"}}', context, {}, themeSettings))
+            .to.be.equal('/assets/cdn/customcdn/img/image.jpg');
+
+        expect(c('{{cdn "customcdn:/img/image.jpg"}}', context, {}, themeSettings))
+            .to.be.equal('/assets/cdn/customcdn/img/image.jpg');
+
+        done();
+    });
+
+    it('should not return a custom CDN asset if protocol is not configured', function (done) {
+
+        expect(c('{{cdn "customcdn:img/image.jpg"}}', context, settings, {}))
+            .to.be.equal('/img/image.jpg');
+
+        expect(c('{{cdn "customcdn:/img/image.jpg"}}', context, settings, {}))
             .to.be.equal('/img/image.jpg');
 
         done();
@@ -94,10 +134,10 @@ describe('cdn helper', function () {
 
     it('should return basic asset URL if protocol is not correct', function (done) {
 
-        expect(c('{{cdn "randomProtocol::img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "randomProtocol::img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('/img/image.jpg');
 
-        expect(c('{{cdn "randomProtocol:/img/image.jpg"}}', context, settings))
+        expect(c('{{cdn "randomProtocol:/img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('/img/image.jpg');
 
         done();

--- a/test/helpers/cdn.js
+++ b/test/helpers/cdn.js
@@ -19,9 +19,8 @@ describe('cdn helper', function () {
     };
     var themeSettings = {
       cdn: {
-        customcdn: {
-          path: 'https://bigcommerce.customcdn.net'
-        }
+        customcdn1: 'https://bigcommerce.customcdn.net',
+        customcdn2: 'http://cdn.mystore.com'
       }
     };
 
@@ -101,43 +100,61 @@ describe('cdn helper', function () {
 
     it('should return a custom CDN asset if protocol is configured', function (done) {
 
-        expect(c('{{cdn "customcdn:img/image.jpg"}}', context, settings, themeSettings))
+        expect(c('{{cdn "customcdn1:img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
 
-        expect(c('{{cdn "customcdn:/img/image.jpg"}}', context, settings, themeSettings))
+        expect(c('{{cdn "customcdn1:/img/image.jpg"}}', context, settings, themeSettings))
             .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
+
+        expect(c('{{cdn "customcdn2:img/image.jpg"}}', context, settings, themeSettings))
+            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
+
+        expect(c('{{cdn "customcdn2:/img/image.jpg"}}', context, settings, themeSettings))
+            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
 
         done();
     });
 
     it('should return a custom CDN asset when using nested helper', function (done) {
 
-        expect(c('{{cdn (concat "customcdn:" "img/image.jpg")}}', context, settings, themeSettings))
+        expect(c('{{cdn (concat "customcdn1:" "img/image.jpg")}}', context, settings, themeSettings))
             .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
 
-        expect(c('{{cdn (concat "customcdn:" "/img/image.jpg")}}', context, settings, themeSettings))
+        expect(c('{{cdn (concat "customcdn1:" "/img/image.jpg")}}', context, settings, themeSettings))
             .to.be.equal('https://bigcommerce.customcdn.net/img/image.jpg');
+
+        expect(c('{{cdn (concat "customcdn2:" "img/image.jpg")}}', context, settings, themeSettings))
+            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
+
+        expect(c('{{cdn (concat "customcdn2:" "/img/image.jpg")}}', context, settings, themeSettings))
+            .to.be.equal('http://cdn.mystore.com/img/image.jpg');
 
         done();
     });
 
     it('should return a local CDN asset if no cdn url is configured', function (done) {
 
-        expect(c('{{cdn "customcdn:img/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('/assets/cdn/customcdn/img/image.jpg');
+        expect(c('{{cdn "customcdn1:img/image.jpg"}}', context, {}, themeSettings))
+            .to.be.equal('/assets/cdn/customcdn1/img/image.jpg');
 
-        expect(c('{{cdn "customcdn:/img/image.jpg"}}', context, {}, themeSettings))
-            .to.be.equal('/assets/cdn/customcdn/img/image.jpg');
+        expect(c('{{cdn "customcdn1:/img/image.jpg"}}', context, {}, themeSettings))
+            .to.be.equal('/assets/cdn/customcdn1/img/image.jpg');
+
+        expect(c('{{cdn "customcdn2:img/image.jpg"}}', context, {}, themeSettings))
+            .to.be.equal('/assets/cdn/customcdn2/img/image.jpg');
+
+        expect(c('{{cdn "customcdn2:/img/image.jpg"}}', context, {}, themeSettings))
+            .to.be.equal('/assets/cdn/customcdn2/img/image.jpg');
 
         done();
     });
 
     it('should not return a custom CDN asset if protocol is not configured', function (done) {
 
-        expect(c('{{cdn "customcdn:img/image.jpg"}}', context, settings, {}))
+        expect(c('{{cdn "customcdn1:img/image.jpg"}}', context, settings, {}))
             .to.be.equal('/img/image.jpg');
 
-        expect(c('{{cdn "customcdn:/img/image.jpg"}}', context, settings, {}))
+        expect(c('{{cdn "customcdn1:/img/image.jpg"}}', context, settings, {}))
             .to.be.equal('/img/image.jpg');
 
         done();


### PR DESCRIPTION
This pull request allows theme creators to define custom CDN endpoints, and use them via the `cdn` handlebars helper.

When designing themes for BigCommerce, theme designers might want to include large, high resolution image assets as components of their theme. For example on maruccisports.com, each product category includes a 5120x2536 background image, most of which are between 3 and 5 MB. Since sending that much image data down the wire is a poor user experience, we use Imgix to resize and reformat the images depending on the device viewing them. A theme designer might want to use a local version of the image in development, and a version on a CDN like Imgix in production. This pull request allows the designer to define endpoints in their theme's `config.json` file like this:
```json
{
  "name": "Cornerstone",
  "version": "1.3.2",
  "settings": {
    "homepage_new_products_count": 12,
    "homepage_featured_products_count": 8,
    "cdn": {
      "customcdn": {
        "path": "https://bigcommerce.customcdn.net"
      }
    }
  }
}
```

After defining an endpoint, the theme designer is then able to use the shortname the same way they currently use the `webdav` one:
```handlebars
<img src="{{cdn "customcdn:img/image.jpg"}}" />
```

In development, the previous helper would return the following:
```html
<img src="/assets/cdn/customcdn/img/image.jpg" />
```

And in production:
```html
<img src="https://bigcommerce.customcdn.net/img/image.jpg" />
```

Right now, the helper is configured to rewrite local URLs to a `cdn` folder within `assets`. This is to circumvent the 50MB bundle size limit by excluding `assets/cdn` from the bundle created by `stencil bundle`. In addition to this PR, I've filed one that makes this change against the stencil-cli repo. bigcommerce/stencil-cli#240