### PR TITLE
adjust if helper to support subexpressions

### DIFF
--- a/helpers/if.js
+++ b/helpers/if.js
@@ -77,10 +77,14 @@ function helper(paper) {
             }
         }
 
-        if (result) {
-            return options.fn(this);
-        } else {
-            return options.inverse(this);
+        if (options.fn) { // block helper
+            if (result) {
+                return options.fn(this);
+            } else {
+                return options.inverse(this);
+            }
+        } else { // non-block helper
+            return result;
         }
     });
 }

--- a/test/helpers/if.js
+++ b/test/helpers/if.js
@@ -220,4 +220,14 @@ describe('if helper', function() {
         done();
     });
 
+    it('should work as a non-block helper when used as a subexpression', function(done) {
+        expect(c('{{#if (if num1 "!==" num2)}}{{big}}{{/if}}', context))
+            .to.be.equal('big');
+
+        expect(c('{{#all (if num1 "!==" num2) "1" true}}big{{/all}}', context))
+            .to.be.equal('big');
+
+        done();
+    });
+
 });


### PR DESCRIPTION
adds the ability to use the if helper as a subexpression

context:
https://github.com/assemble/handlebars-helpers/issues/224
https://github.com/assemble/handlebars-helpers/pull/225/files#diff-63430960261956d4a86cbd6cf21d229aR539

why:
to prevent this kind of thing:  https://github.com/bigcommerce/stencil/blob/28eea2f9e8e88b4fdc43a2bc01c264d2989261f9/templates/components/products/card.html#L84-L98

instead it could be:
```
{{#or customer if(theme_settings.restrict_to_login '===' false)}}
            <div class="card-text" data-test-info-type="price">
                {{> components/products/price price=price customer=../../customer}}
            </div>
{{else}}
            <div class="card-text" data-test-info-type="price">
                <p translate>Log in for pricing</p>
            </div>
{{/or}}
```
or

```
{{#all theme_settings.restrict_to_login if(customer '!=' true)}}
            <div class="card-text" data-test-info-type="price">
                <p translate>Log in for pricing</p>
            </div>
{{else}}
            <div class="card-text" data-test-info-type="price">
                {{> components/products/price price=price customer=../../customer}}
            </div>
{{/all}}
```
