### PR TITLE
STENCIL-2919 template_file issue fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ Paper.prototype.render = function (path, context) {
     var output;
 
     context = context || {};
-    context.template_file = path;
+    context.template = path;
 
     if (this.translate) {
         context.locale_name = this.translate.localeName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Turns out we can not change `template_file` to point to a custom template because it is used as the page type by Cornerstone and all its custom themes. (This is what broke custom templates this morning)

![image](https://cloud.githubusercontent.com/assets/1934727/22128875/a4e4bd04-de57-11e6-85c7-f57caa8f0acd.png)

Cornerstone uses `template_file`as a map to load classes:
![image](https://cloud.githubusercontent.com/assets/1934727/22129035/8317565e-de58-11e6-918d-bff80855a743.png)

The proposed solution is to deprecate `template_file` and use `template` instead

@mattolson @lord2800 @bc-julianleong 