### PR TITLE
BIG-29681 catch MerssageFormat syntax errors

### DIFF
--- a/lib/localizer.js
+++ b/lib/localizer.js
@@ -126,7 +126,16 @@ internals.getTranslator = function (localeName, translations) {
         }
 
         if (typeof translations[key] !== 'function') {
-            translations[key] = formatter.compile(translations[key]);
+            try {
+                translations[key] = formatter.compile(translations[key]);
+            } catch (err) {
+                if (err.name === 'SyntaxError') {
+                    console.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
+                    return '';
+                }
+
+                throw err;
+            }
         }
 
         try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
https://jira.bigcommerce.com/browse/BIG-29681

Stapler should not crash if there is a syntax error in translation files

@lord2800 @mjschock 