### PR TITLE
Added a handlebars helper to truncate a string

### DIFF
--- a/helpers/truncate.js
+++ b/helpers/truncate.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/* 2017-02-14
+ * 
+ * FUNCTION
+ * truncate(str, length)
+ *
+ * DESCRIPTION (WHAT)
+ * Returns the first X characters in a string (unless it reaches the end 
+ * of the string first, in which case it will return fewer). Returns a 
+ * new string that is truncated to the given length.
+ *
+ * USE CASE (WHY)
+ * As a merchant, I want to display a card, at the bottom of
+ * my home page that highlights the most recent blog post. In the card,
+ * I want to display the blog thumbnail, title and the first 40 characters
+ * of the post's body. In order to extract the first 40 characters, I need
+ * a Handlebars helper that works like the javascript substring() function. 
+ * 
+ * USAGE
+ *
+ *  {{lang (truncate 'blog.post.body.' 40) }}
+ */
+function helper(paper) {
+    paper.handlebars.registerHelper('truncate', function (s, length) {
+        if (typeof s !== 'string') {
+            return s;
+        }
+        var str = s.substring(0, length)
+        return new paper.handlebars.SafeString(str);
+    });
+}
+
+module.exports = helper;

--- a/test/helpers/truncate.js
+++ b/test/helpers/truncate.js
@@ -13,8 +13,8 @@ function c(template, context) {
 describe('truncate helper', function() {
 
     var context = {
-      string: "hello world",
-      number: 2
+        string: 'hello world',
+        number: 2
     };
 
     it('should return the entire string if length is longer than the input string', function(done) {

--- a/test/helpers/truncate.js
+++ b/test/helpers/truncate.js
@@ -1,0 +1,40 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    return new Paper().loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('truncate helper', function() {
+
+    var context = {
+      string: "hello world",
+      number: 2
+    };
+
+    it('should return the entire string if length is longer than the input string', function(done) {
+
+        expect(c('{{truncate string 15}}', context))
+            .to.be.equal('hello world');
+        done();
+    });
+
+    it('should return the first length number of characters', function(done) {
+
+        expect(c('{{truncate string 5}}', context))
+            .to.be.equal('hello');
+        done();
+    });
+
+    it('should return the first argument, coerced to a string, if it is not a string', function(done) {
+
+        expect(c('{{truncate number 5}}', context))
+            .to.be.equal('2');
+        done();
+    });
+});


### PR DESCRIPTION
**FUNCTION**
truncate(str, length)

**DESCRIPTION (WHAT)**
Returns the first X characters in a string (unless it reaches the end 
of the string first, in which case it will return fewer). Returns a 
new string that is truncated to the given length.

**USE CASE (WHY)**
As a merchant, I want to display a card, at the bottom of
my home page that highlights the most recent blog post. In the card,
I want to display the blog thumbnail, title and the first 40 characters
of the post's body. In order to extract the first 40 characters, I need
a Handlebars helper that works like the javascript substring() function. 
 
**USAGE**
{{lang (truncate 'blog.post.body.' 40) }}

@mcampa , @junedkazi , @mjschock 