### PR TITLE
Fix the truncation of unicode strings

### DIFF
--- a/helpers/truncate.js
+++ b/helpers/truncate.js
@@ -1,13 +1,15 @@
 'use strict';
 
+const substring = require('stringz').substring;
+
 /* 2017-02-14
- * 
+ *
  * FUNCTION
  * truncate(str, length)
  *
  * DESCRIPTION (WHAT)
- * Returns the first X characters in a string (unless it reaches the end 
- * of the string first, in which case it will return fewer). Returns a 
+ * Returns the first X characters in a string (unless it reaches the end
+ * of the string first, in which case it will return fewer). Returns a
  * new string that is truncated to the given length.
  *
  * USE CASE (WHY)
@@ -15,19 +17,21 @@
  * my home page that highlights the most recent blog post. In the card,
  * I want to display the blog thumbnail, title and the first 40 characters
  * of the post's body. In order to extract the first 40 characters, I need
- * a Handlebars helper that works like the javascript substring() function. 
- * 
+ * a Handlebars helper that works like the javascript substring() function.
+ *
  * USAGE
  *
  *  {{lang (truncate 'blog.post.body.' 40) }}
  */
 function helper(paper) {
-    paper.handlebars.registerHelper('truncate', function (s, length) {
-        if (typeof s !== 'string') {
-            return s;
+    paper.handlebars.registerHelper('truncate', function (string, length) {
+        if (typeof string !== 'string') {
+            return string;
         }
-        var str = s.substring(0, length)
-        return new paper.handlebars.SafeString(str);
+
+        const truncatedString = substring(string, 0, length);
+
+        return new paper.handlebars.SafeString(truncatedString);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hoek": "^2.12.0",
     "lodash": "^3.6.0",
     "messageformat": "^0.2.2",
+    "stringz": "^0.1.1",
     "tarjan-graph": "^0.3.0"
   },
   "devDependencies": {

--- a/test/helpers/truncate.js
+++ b/test/helpers/truncate.js
@@ -13,8 +13,11 @@ function c(template, context) {
 describe('truncate helper', function() {
 
     var context = {
+        chinese_string: '𠜎𠜱𠝹𠱓𠱸𠲖𠳏',
+        number: 2,
+        spanish_string: 'mañana',
         string: 'hello world',
-        number: 2
+        unicode_string: 'She ❤️️ this',
     };
 
     it('should return the entire string if length is longer than the input string', function(done) {
@@ -35,6 +38,25 @@ describe('truncate helper', function() {
 
         expect(c('{{truncate number 5}}', context))
             .to.be.equal('2');
+        done();
+    });
+
+    it('should handle non-English strings', function(done) {
+
+        expect(c('{{truncate spanish_string 3}}', context))
+            .to.be.equal('mañ');
+
+        expect(c('{{truncate chinese_string 3}}', context))
+            .to.be.equal('𠜎𠜱𠝹');
+
+        done();
+    });
+
+    it('should handle unicode strings', function(done) {
+
+        expect(c('{{truncate unicode_string 5}}', context))
+            .to.be.equal('She ❤️');
+
         done();
     });
 });


### PR DESCRIPTION
## What?
* #106 added a truncation helper. It uses `String.prototype.substring` to truncate strings. However, the native function doesn't handle unicode characters properly. So, if you call the truncate helper on strings containing unicode characters (some non-English characters or emoji), you won't get what you expect.
* To save time, I decided to use a third party library called [stringz](https://www.npmjs.com/package/stringz). It has MIT license, so we should be good to use.

## Why?
* This is necessary because we need to support multiple languages in Stencil.

## Testing / Proof
* Unit

@bigcommerce/checkout @bigcommerce/stencil-team 
