### PR TITLE
STENCIL-3361 Remove configId from assets urls

### DIFF
--- a/helpers/stylesheet.js
+++ b/helpers/stylesheet.js
@@ -1,30 +1,24 @@
 'use strict';
 
-var _ = require('lodash');
+const _ = require('lodash');
 
 function helper(paper) {
     paper.handlebars.registerHelper('stylesheet', function (assetPath) {
         const options = arguments[arguments.length - 1];
-        const url = paper.cdnify(assetPath);
-        var attrs = {
-            rel: 'stylesheet'
-        };
+        const configId = paper.settings['theme_config_id'];
+        const path = configId ? assetPath.replace(/\.css$/, `-${configId}.css`) : assetPath;
+        const url = paper.cdnify(path);
+
+        let attrs = { rel: 'stylesheet' };
 
         // check if there is any extra attribute
         if (_.isObject(options.hash)) {
             attrs = _.merge(attrs, options.hash);
         }
 
-        if (!attrs.id) {
-            attrs.id = url;
-        }
+        attrs = _.map(attrs, (value, key) => `${key}="${value}"`).join( ' ');
 
-        attrs = _.map(attrs, function (value, key) {
-            return key + '="' + value + '"';
-        }).join(' ');
-
-
-        return '<link data-stencil-stylesheet href="' + url + '" ' + attrs + '>';
+        return `<link data-stencil-stylesheet href="${url}" ${attrs}>`;
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -202,7 +202,6 @@ Paper.prototype.loadTranslations = function (acceptLanguage, callback) {
 Paper.prototype.cdnify = function (path) {
     var cdnUrl = this.settings['cdn_url'] || '';
     var versionId = this.settings['theme_version_id'];
-    var configId = this.settings['theme_config_id'];
     var sessionId = this.settings['theme_session_id'];
     var protocolMatch = /(.*!?:)/;
 
@@ -252,7 +251,7 @@ Paper.prototype.cdnify = function (path) {
         path = '/' + path;
     }
 
-    if (!versionId || !configId) {
+    if (!versionId) {
         return path;
     }
 
@@ -261,10 +260,10 @@ Paper.prototype.cdnify = function (path) {
     }
 
     if (sessionId) {
-        return [cdnUrl, 'stencil', versionId, configId, 'e', sessionId, path].join('/');
+        return [cdnUrl, 'stencil', versionId, 'e', sessionId, path].join('/');
     }
 
-    return [cdnUrl, 'stencil', versionId, configId, path].join('/');
+    return [cdnUrl, 'stencil', versionId, path].join('/');
 };
 
 /**

--- a/test/helpers/cdn.js
+++ b/test/helpers/cdn.js
@@ -15,7 +15,6 @@ describe('cdn helper', function () {
     var settings = {
         cdn_url: 'https://cdn.bcapp/3dsf74g',
         theme_version_id: '123',
-        theme_config_id: '3245',
     };
     var themeSettings = {
         cdn: {
@@ -26,20 +25,20 @@ describe('cdn helper', function () {
 
     it('should render the css cdn url', function (done) {
         expect(c('{{cdn "assets/css/style.css"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/css/style.css');
+            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/css/style.css');
 
         expect(c('{{cdn "/assets/css/style.css"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/css/style.css');
+            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/css/style.css');
 
         done();
     });
 
     it('should render normal assets cdn url', function (done) {
         expect(c('{{cdn "assets/js/app.js"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/js/app.js');
+            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/js/app.js');
 
         expect(c('{{cdn "assets/img/image.jpg"}}', context, settings, themeSettings))
-            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/3245/img/image.jpg');
+            .to.be.equal('https://cdn.bcapp/3dsf74g/stencil/123/img/image.jpg');
 
         done();
     });

--- a/test/helpers/stylesheet.js
+++ b/test/helpers/stylesheet.js
@@ -7,32 +7,39 @@ var Code = require('code'),
     it = lab.it;
 
 function c(template, settings) {
-    return new Paper(settings).loadTemplatesSync({template: template}).render('template', {});
+    return new Paper(settings).loadTemplatesSync({ template }).render('template', {});
 }
 
-describe('stylesheet helper', function () {
+describe('stylesheet helper', () => {
     var settings = {
         cdn_url: 'https://cdn.bcapp/hash',
-        theme_version_id: '1',
-        theme_config_id: '2',
+        theme_version_id: '123',
+        theme_config_id: 'xyz',
     };
-    it('should render a link tag with the cdn ulr and stencil-stylesheet data tag', function (done) {
+    it('should render a link tag with the cdn ulr and stencil-stylesheet data tag', done => {
         expect(c('{{{stylesheet "assets/css/style.css"}}}', settings))
-            .to.be.equal('<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/1/2/css/style.css" rel="stylesheet" id="https://cdn.bcapp/hash/stencil/1/2/css/style.css">');
+            .to.be.equal('<link data-stencil-stylesheet href="https://cdn.bcapp/hash/stencil/123/css/style-xyz.css" rel="stylesheet">');
 
         done();
     });
 
-    it('should render a link tag and all extra attributes with no cdn url', function (done) {
-        expect(c('{{{stylesheet "assets/css/style.css" rel="something" class="myStyle"}}}', {}))
-            .to.be.equal('<link data-stencil-stylesheet href="/assets/css/style.css" rel="something" class="myStyle" id="/assets/css/style.css">');
+    it('should render a link tag and all extra attributes with no cdn url', done => {
+        expect(c('{{{stylesheet "assets/css/style.css" fuck rel="something" class="myStyle"}}}', {}))
+            .to.be.equal('<link data-stencil-stylesheet href="/assets/css/style.css" rel="something" class="myStyle">');
 
         done();
     });
 
-    it('should render a link with empty href', function (done) {
+    it('should render a link with empty href', done => {
         expect(c('{{{stylesheet "" }}}'))
-            .to.be.equal('<link data-stencil-stylesheet href="" rel="stylesheet" id="">');
+            .to.be.equal('<link data-stencil-stylesheet href="" rel="stylesheet">');
+
+        done();
+    });
+
+    it('should add configId to the filename', done => {
+        expect(c('{{{stylesheet "assets/css/style.css" }}}', { theme_config_id: 'foo' }))
+            .to.be.equal('<link data-stencil-stylesheet href="/assets/css/style-foo.css" rel="stylesheet">');
 
         done();
     });

--- a/test/index.js
+++ b/test/index.js
@@ -94,11 +94,10 @@ describe('cdnify()', function () {
         var paper = new Paper({
             cdn_url: 'http://cdn.example.com/foo',
             theme_version_id: '123',
-            theme_config_id: '234',
         });
 
         expect(paper.cdnify('/assets/image.jpg'))
-            .to.be.equal('http://cdn.example.com/foo/stencil/123/234/image.jpg');
+            .to.be.equal('http://cdn.example.com/foo/stencil/123/image.jpg');
 
         done();
     });
@@ -107,12 +106,11 @@ describe('cdnify()', function () {
         var paper = new Paper({
             cdn_url: 'http://cdn.example.com/foo',
             theme_version_id: '123',
-            theme_config_id: '234',
             theme_session_id: '345',
         });
 
         expect(paper.cdnify('/assets/image.jpg'))
-            .to.be.equal('http://cdn.example.com/foo/stencil/123/234/e/345/image.jpg');
+            .to.be.equal('http://cdn.example.com/foo/stencil/123/e/345/image.jpg');
 
         done();
     });


### PR DESCRIPTION
- Move the config id on the css to css file name
- Remove the config id from asset file path to make sure the assets continue to server from the cdn & the cache is still maintained & not busted since they don’t change per configuration.
