### PR TITLE
STENCIL-3323 - Fix thumbnailImage helper

### DIFF
--- a/helpers/thirdParty.js
+++ b/helpers/thirdParty.js
@@ -61,7 +61,7 @@ const whitelist = [
     },
     {
         name: 'html',
-        include: ['ellipsis', 'sanitize', 'ul', 'ol', 'thumbnail']
+        include: ['ellipsis', 'sanitize', 'ul', 'ol', 'thumbnailImage']
     },
     {
         name: 'inflection',

--- a/test/helpers/thirdParty.js
+++ b/test/helpers/thirdParty.js
@@ -88,6 +88,26 @@ describe('third party handlebars-helpers', function() {
             });
         });
 
+        describe('contains thumbnailImage', function() {
+            it('creates a <figure> with a thumbnail linked to an image', function(done) {
+                const ctxt = {
+                    data: {
+                        id: 'id',
+                        alt: 'alt',
+                        thumbnail: 'thumbnail.png',
+                        size: {
+                            width: 32,
+                            height: 32
+                        }
+                    }
+                };
+                expect(c(`{{{thumbnailImage data}}}`, ctxt)).to.be
+                    .equal('<figure id=\"image-id\">\n<img alt=\"alt\" src=\"thumbnail.png\" width=\"32\" height=\"32\">\n</figure>');
+
+                done();
+            });
+        });
+
     });
 
     describe('inflection helpers', function() {


### PR DESCRIPTION
## WHAT
* this adds the `{{thumbnailImage}}` helper and removes the non-existent `{{thumbnail}}` helper.

## VALIDATE
* you can now use the helper as shown below
  * https://github.com/helpers/handlebars-helpers/blob/master/lib/html.js#L203
  * https://github.com/helpers/handlebars-helpers/blob/master/test/html.js#L147

@bigcommerce/stencil-team @bookernath 