### PR TITLE
Region helper MERC-2432

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
     "modules": true
   },
   "env": {
-    "node": true,
+    "node": true
   },
   "globals": {
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 4.4.7
+  - 4
+  - 6
+  
 script:
   - npm install
   - npm install -g gulp-cli

--- a/helpers/region.js
+++ b/helpers/region.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function helper(paper) {
+    paper.handlebars.registerHelper('region', function (params) {
+        let regionId = params.hash.name;
+        let content = '';
+
+        if (!paper.renderingContext || !paper.renderingContext.regions) {
+            return '';
+        }
+
+        if (paper.renderingContext.regions[regionId]) {
+            content = `<div data-content-region="${regionId}">${paper.renderingContext.regions[regionId]}</div>`;
+        }
+
+        return new paper.handlebars.SafeString(content);
+    });
+}
+
+module.exports = helper;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "accept-language-parser": "^1.0.2",
     "async": "^1.4.2",
-    "handlebars": "^3.0.1",
+    "handlebars": "^4.0.10",
     "handlebars-helpers": "^0.8.0",
     "lodash": "^3.6.0",
     "messageformat": "^0.2.2",

--- a/test/helpers/region.js
+++ b/test/helpers/region.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const Code = require('code');
+const Lab = require('lab');
+const Paper = require('../../index');
+
+const lab = exports.lab = Lab.script();
+const before = lab.before;
+const describe = lab.experiment;
+const expect = Code.expect;
+const it = lab.it;
+
+function compile(paper, template, context) {
+    context = context || {};
+    return paper.loadTemplatesSync({
+        template: template
+    }).render('template', context);
+}
+
+describe('Region Helper', () => {
+    let context;
+    let paper;
+
+    before(done => {
+        context = {
+            regions: {
+                'banner-top': "hello world"
+            }
+        };
+
+        paper = new Paper();
+        paper.renderingContext = context;
+
+        done();
+    });
+
+    it('should return an empty string if no content service data (missing renderingContext) on page context', done => {
+        let noPaperContext = new Paper();
+        expect(compile(noPaperContext, '{{region name="banner-bottom"}}', context))
+            .to.be.equal('');
+
+        done();
+    });
+
+    it('should return an empty string if no matching region on context object', done => {
+        expect(compile(paper, '{{region name="banner-bottom"}}', context))
+            .to.be.equal('');
+
+        done();
+    });
+
+    it('should return Hello World', done => {
+        expect(compile(paper, '{{region name="banner-top"}}', context))
+            .to.be.equal('<div data-content-region="banner-top">hello world</div>');
+
+        done();
+    });
+
+});


### PR DESCRIPTION
What:
This PR extends Paper by adding a location helper for content blocks. This enables access inside the helper to using all the available helpers for rendering inside Paper.

Depends on:
https://github.com/bigcommerce/paper/pull/118. 


06/14 -- Updated names to __Region__ based on new content service nomenclature

