### PR TITLE
Upgrade lodash

### DIFF
--- a/helpers/all.js
+++ b/helpers/all.js
@@ -22,7 +22,7 @@ function helper(paper) {
         opts = args.pop();
 
         // Check if all the arguments are valid / truthy
-        result = _.all(args, function (arg) {
+        result = _.every(args, function (arg) {
             if (_.isArray(arg)) {
                 return !!arg.length;
             }

--- a/helpers/any.js
+++ b/helpers/any.js
@@ -27,11 +27,11 @@ function helper(paper) {
 
         if (!_.isEmpty(predicate)) {
             // With options hash, we check the contents of first argument
-            any = _.any(args[0], predicate);
+            any = _.some(args[0], predicate);
         } else {
             // DEPRECATED: Moved to #or helper
             // Without options hash, we check all the arguments
-            any = _.any(args, function (arg) {
+            any = _.some(args, function (arg) {
                 if (_.isArray(arg)) {
                     return !!arg.length;
                 }

--- a/helpers/contains.js
+++ b/helpers/contains.js
@@ -13,7 +13,7 @@ function helper(paper) {
     paper.handlebars.registerHelper('contains', function () {
         var args = Array.prototype.slice.call(arguments, 0, -1),
             options = _.last(arguments),
-            contained = _.contains.apply(_, args);
+            contained = _.includes.apply(_, args);
 
         // Yield block if true
         if (contained) {

--- a/helpers/or.js
+++ b/helpers/or.js
@@ -23,7 +23,7 @@ function helper(paper) {
         opts = args.pop();
 
         // Without options hash, we check all the arguments
-        any = _.any(args, function (arg) {
+        any = _.some(args, function (arg) {
             if (_.isArray(arg)) {
                 return !!arg.length;
             }

--- a/helpers/pluck.js
+++ b/helpers/pluck.js
@@ -4,7 +4,7 @@ var _ = require('lodash');
 
 function helper(paper) {
     paper.handlebars.registerHelper('pluck', function (collection, path) {
-        return _.pluck(collection, path);
+        return _.map(collection, path);
     });
 }
 

--- a/lib/translator/filter.js
+++ b/lib/translator/filter.js
@@ -15,7 +15,7 @@ const _ = require('lodash');
 function filterByKey(language, keyFilter) {
     return _.transform(language, (result, value, key) => {
         if (key === 'translations' || key === 'locales') {
-            result[key] = _.pick(value, (innerValue, innerKey) => innerKey.indexOf(keyFilter) === 0);
+            result[key] = _.pickBy(value, (innerValue, innerKey) => innerKey.indexOf(keyFilter) === 0);
         } else {
             result[key] = value;
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^1.4.2",
     "handlebars": "^3.0.1",
     "handlebars-helpers": "^0.8.0",
-    "lodash": "^3.6.0",
+    "lodash": "^4.17.4",
     "messageformat": "^0.2.2",
     "stringz": "^0.1.1",
     "tarjan-graph": "^0.3.0"


### PR DESCRIPTION
## WHAT
* this upgrades lodash to 4.x.

## WHY
* this prepares for the stencil-cli dep upgrade (https://github.com/bigcommerce/stencil-cli/pull/332) which includes a lodash upgrade.  when stencil-cli with lodash 4.x pulls in paper with lodash 3.x, it uses lodash 4.x to run the paper lodash functions.  i found this happens with npm 2.x anyway.

## TESTING
* i tried running `stencil start` with two versions of cli, one using lodash 4.x and the other 3.x.  both scenarios produce a working store at localhost

@mcampa cc @bigcommerce/stencil-team 
