### PR TITLE
STRF-4420: Remove direct access to siteSettings and themeSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,26 @@
 # Changelog
 
-## 3.0.0-rc.1 (2018-01-10)
-Refactor rendering functionality into paper-handlebars [#130](https://github.com/bigcommerce/paper/pull/130) to
+## 3.0.0-rc.2 (2018-01-31)
+- Major refactor, moving rendering functionality into paper-handlebars [#130](https://github.com/bigcommerce/paper/pull/130) to
 allow for alternate template engines.
+- Remove access to siteSettings and themeSettings, use accessors instead [#131](https://github.com/bigcommerce/paper/pull/131) to
 
 v3.0 Contains several breaking changes:
-- Removed the direct access of `contentServiceContext` for setting page content. From now on, use `addContent()` and `getContent()`.
+- Removed the direct access of `contentServiceContext` for setting page content. From now on, use `setContent()`
+  and `getContent()`.
+- Removed direct access of `siteSettings` and `themeSettings`. From now on, use `getSiteSettings()`, `setSiteSettings()`,
+  `getThemeSettings()`, and `setThemeSettings()` if you need to get/set these values after calling the constructor.
 - Removed `getTemplateProcessor()`. This is an internal concern of `paper-handlebars` and is used by `loadTemplates`.
 - Removed `loadTemplatesSync()`. This was only used by helper tests and is no longer needed.
-- Removed `handlebars` instance variable. Hopefully nobody is accessing that directly. Any helpers that were accessing it have been updated in `paper-handlebars` to use the global context they are given rather than accessing Paper directly at all.
+- Removed `handlebars` instance variable. Hopefully nobody is accessing that directly. Any helpers that were accessing
+  it have been updated in `paper-handlebars` to use the global context they are given rather than accessing Paper
+  directly at all.
 - The `translator` attribute has been moved to `paper-handlebars` and is no longer accessible directly on Paper.
 - The `decorators` attribute has been moved to `paper-handlebars` and is no longer accessible directly on Paper.
 - The `settings` attribute has been renamed to `siteSettings`. This should only be accessed by `paper-handlebars`.
 - The `cdnify()` function has been moved into a helper library in `paper-handlebars`.
-- The `inject` attribute has been removed. This is storage used by two of the helpers, and the implementation has moved to `paper-handlebars`.
+- The `inject` attribute has been removed. This is storage used by two of the helpers, and the implementation has
+  moved to `paper-handlebars`.
 
 ## 2.0.7 (2017-10-17)
 - Always render region wrapper even if no content is present [#128](https://github.com/bigcommerce/paper/pull/128)

--- a/index.js
+++ b/index.js
@@ -62,23 +62,91 @@ class Paper {
     * @param {assemblerGetTranslations} assembler.getTranslations - Method to assemble translations
     */
     constructor(siteSettings, themeSettings, assembler, rendererType) {
-        this.siteSettings = siteSettings || {};
-        this.themeSettings = themeSettings || {};
-        this.assembler = assembler || {};
+        this._assembler = assembler || {};
 
         // Build renderer based on type
         switch(rendererType) {
         case 'handlebars-v4':
-            this.renderer = new HandlebarsRenderer(this.siteSettings, this.themeSettings, 'v4');
+            this.renderer = new HandlebarsRenderer(siteSettings, themeSettings, 'v4');
             break;
         case 'handlebars-v3':
         default:
-            this.renderer = new HandlebarsRenderer(this.siteSettings, this.themeSettings, 'v3');
+            this.renderer = new HandlebarsRenderer(siteSettings, themeSettings, 'v3');
             break;
         }
 
         this.preProcessor = this.renderer.getPreProcessor();
     }
+
+    /**
+     * Get the siteSettings object containing global site settings.
+     *
+     * @return {object} settings An object containing global site settings.
+     */
+    getSiteSettings() {
+        return this.renderer.getSiteSettings();
+    };
+
+    /**
+     * Set the siteSettings object containing global site settings.
+     *
+     * @param {object} settings An object containing global site settings.
+     */
+    setSiteSettings(settings) {
+        this.renderer.setSiteSettings(settings);
+    };
+
+    /**
+     * Get the themeSettings object containing the theme configuration.
+     *
+     * @return {object} settings An object containing the theme configuration.
+     */
+    getThemeSettings() {
+        return this.renderer.getThemeSettings();
+    };
+
+    /**
+     * Set the themeSettings object containing the theme configuration.
+     *
+     * @param {object} settings An object containing the theme configuration.
+     */
+    setThemeSettings(settings) {
+        this.renderer.setThemeSettings(settings);
+    };
+
+    /**
+     * Reset decorator list.
+     */
+    resetDecorators() {
+        this.renderer.resetDecorators();
+    };
+
+    /**
+     * Add a decorator to wrap output during render().
+     *
+     * @param {Function} decorator
+     */
+    addDecorator(decorator) {
+        this.renderer.addDecorator(decorator);
+    };
+
+    /**
+     * Get page content.
+     *
+     * @return {Object} Regions with widgets
+     */
+    getContent() {
+        return this.renderer.getContent();
+    };
+
+    /**
+     * Add content to be rendered in the given regions.
+     *
+     * @param {Object} Regions with widgets
+     */
+    setContent(regions) {
+        this.renderer.setContent(regions);
+    };
 
     /**
      * Use the assembler to fetch partials/templates, and translations, then load them
@@ -111,7 +179,7 @@ class Paper {
      * @param {Function} callback
     */
     loadTemplates(path, callback) {
-        this.assembler.getTemplates(path, this.preProcessor, (err, templates) => {
+        this._assembler.getTemplates(path, this.preProcessor, (err, templates) => {
             if (err) {
                 return callback(err);
             }
@@ -144,7 +212,7 @@ class Paper {
      */
     loadTranslations(acceptLanguage, callback) {
         // Ask assembler to fetch translations file
-        this.assembler.getTranslations((err, translations) => {
+        this._assembler.getTranslations((err, translations) => {
             if (err) {
                 return callback(err);
             }
@@ -154,33 +222,6 @@ class Paper {
             this.renderer.setTranslator(translator);
             callback();
         });
-    };
-
-    /**
-     * Add a decorator to wrap output during render().
-     *
-     * @param {Function} decorator
-     */
-    addDecorator(decorator) {
-        this.renderer.addDecorator(decorator);
-    };
-
-    /**
-     * Add content to be rendered in the given regions.
-     *
-     * @param {Object} Regions with widgets
-     */
-    addContent(regions) {
-        this.renderer.addContent(regions);
-    };
-
-    /**
-     * Get page content.
-     *
-     * @return {Object} Regions with widgets
-     */
-    getContent() {
-        return this.renderer.getContent();
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "~2.0.0",
+    "@bigcommerce/stencil-paper-handlebars": "^3.0.0",
     "accept-language-parser": "~1.4.1",
     "async": "~1.5.2",
     "lodash": "~3.10.1",


### PR DESCRIPTION
* Bump paper-handlebars to 3.0
* We no longer store `siteSettings` and `themeSettings` directly on the paper object.
* Create accessors for these objects and delegate them to `HandlebarsRenderer`.
* Change `assembler` attribute to `_assembler` to signal that this should not be accessed directly.
