### PR TITLE
STRF-5485: Change to async interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 4
   - 6
   - 8
+  - 10
 script:
   - npm install
   - npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,29 @@
 # Changelog
 
+## 3.0.0-rc.6 (2018-10-04)
+Breaking change:
+- Use paper-handlebars 4.0.0, which uses Promises for `render` and `renderString`.
+- Change `loadTheme`, `loadTemplates`, `loadTranslations`, `render`, `renderString`,
+  and `renderTheme` to be based on Promises rather than callbacks.
+
+## 3.0.0-rc.5 (2018-08-23)
+- Bump paper-handlebars to 3.0.3 [#136](https://github.com/bigcommerce/paper/pull/136) which adds support for
+  `gtnum` operator in `if` helper.
+
+## 3.0.0-rc.4 (2018-05-31)
+- Bump paper-handlebars to 3.0.2 [#135](https://github.com/bigcommerce/paper/pull/135) which adds the
+  `resourceHints` helper.
+
 ## 3.0.0-rc.3 (2018-01-31)
+- Bump paper-handlebars to 3.0.1 [#132](https://github.com/bigcommerce/paper/pull/132) which has fixes for
+  cdn and stylesheet helpers.
+
+## 3.0.0-rc.2 (2018-01-31)
+- Remove access to siteSettings and themeSettings, use accessors instead [#131](https://github.com/bigcommerce/paper/pull/131)
+
+## 3.0.0-rc.1 (2018-01-24)
 - Major refactor, moving rendering functionality into paper-handlebars [#130](https://github.com/bigcommerce/paper/pull/130) to
 allow for alternate template engines.
-- Remove access to siteSettings and themeSettings, use accessors instead [#131](https://github.com/bigcommerce/paper/pull/131)
-- Bring in bug fix from paper-handlebars [#132](https://github.com/bigcommerce/paper/pull/132)
 
 v3.0 Contains several breaking changes:
 - Removed the direct access of `contentServiceContext` for setting page content. From now on, use `setContent()`
@@ -22,6 +41,12 @@ v3.0 Contains several breaking changes:
 - The `cdnify()` function has been moved into a helper library in `paper-handlebars`.
 - The `inject` attribute has been removed. This is storage used by two of the helpers, and the implementation has
   moved to `paper-handlebars`.
+
+## 2.0.9 (2018-08-14)
+- Add `gtnum` support to `if` helper [#138](https://github.com/bigcommerce/paper/pull/138)
+
+## 2.0.8 (2018-05-09)
+- Add resourceHints helper [#133](https://github.com/bigcommerce/paper/pull/133)
 
 ## 2.0.7 (2017-10-17)
 - Always render region wrapper even if no content is present [#128](https://github.com/bigcommerce/paper/pull/128)

--- a/README.md
+++ b/README.md
@@ -1,46 +1,45 @@
 # stencil-paper
 [![Build Status](https://travis-ci.org/bigcommerce/paper.svg?branch=master)](https://travis-ci.org/bigcommerce/paper) [![npm (scoped)](https://img.shields.io/npm/v/@bigcommerce/stencil-paper.svg)](https://www.npmjs.com/package/@bigcommerce/stencil-paper)
 
-*stencil-paper* is a plugin for `stencil-cli` and `stapler`. Its duty is to load templates and translations, and call out to [paper-handlebars](https://github.com/bigcommerce/paper-handlebars) to render pages.
+*stencil-paper* is a plugin for `stencil-cli`. Its duty is to load templates and translations, and call
+out to [paper-handlebars](https://github.com/bigcommerce/paper-handlebars) to render pages.
 
 ## Usage
-
 Load Paper into your app:
-
 ```
-var Paper = require('@bigcommerce/stencil-paper');
-```
-
-Instatiate paper passing an `assembler`:
-```
-var paper = new Paper(assembler);
+const Paper = require('@bigcommerce/stencil-paper');
 ```
 
-The `assembler` is the interface that paper uses to load the templates and translations. This way we can use paper to load the templates from the file system or any other source.
-Is just an object that implements two methods: `getTemplates()` & `getTranslations()`:
+Instatiate paper passing `siteSettings`, `themeSettings`, and an `assembler`:
 ```
-var assembler = {
-    getTemplates: function (path, processor, callback) {
-      // inplement me
+const paper = new Paper(siteSettings, themeSettings, assembler);
+```
 
-      callback(null, processor(templates));
+The `assembler` is the interface that Paper uses to load the templates and translations. This way we can use paper to load the templates
+from the file system or any other source. It's just an object that implements two methods: `getTemplates()` & `getTranslations()`:
+```
+const assembler = {
+    getTemplates: (path, processor) => {
+        return new Promise((resolve, reject) => {
+            // implement me
+            resolve(processor(templates));
+        });
     },
-    getTranslations: function (callback) {
-      // inplement me
-
-      callback(null, translations);
+    getTranslations: () => {
+        return new Promise((resolve, reject) => {
+            // implement me
+            resolve(translations);
+        });
     }
 };
-
-var paper = new Paper(assembler);
 ```
 
 Now we can load the theme for the page we want to render:
 ```
-paper.loadTheme(path, 'en', function (err) {
-  var html = paper.render(path, context);
-
-  reply(html);
+paper.loadTheme(path, 'en').then(() => {
+    paper.render(path, context).then(html => {
+        reply(html);
+    });
 });
 ```
 
@@ -48,7 +47,6 @@ paper.loadTheme(path, 'en', function (err) {
 See the [stencil API reference](https://stencil.bigcommerce.com/docs/handlebars-helpers-reference) for documentation on the available helpers.
 
 #### License
-
 Copyright (c) 2015-2018, Bigcommerce Inc.
 All rights reserved.
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.5",
+  "version": "3.0.0-rc.6",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
   "license": "BSD-4-Clause",
   "scripts": {
     "linter": "eslint .",
-    "test": "npm run linter && lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics spec",
+    "test": "npm run linter && lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec"
   },
   "repository": {
@@ -23,9 +23,8 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "~3.0.3",
+    "@bigcommerce/stencil-paper-handlebars": "~4.0.0",
     "accept-language-parser": "~1.4.1",
-    "async": "~1.5.2",
     "lodash": "~3.10.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
To prepare for off-loading render tasks to a separate thread pool, update interfaces to be Promise-based rather than return synchronous results. This is a breaking change, but since we are still in release candidate stage, we can stay at 3.0.

Breaking changes:
* Use paper-handlebars 4.0.0, which uses Promises for `render` and `renderString`.
* Change `loadTheme`, `loadTemplates`, `loadTranslations`, `render`, `renderString`, and `renderTheme` to be based on Promises rather than callbacks.
* Update assembler interface to expect that it returns a promise.
* Drop support for Node 4.x

Other changes:
* Remove Async dependency
* Fill out missing changelog entries
* Update readme to demonstrate new interface
* Add support for Node 10.x

Depends on https://github.com/bigcommerce/paper-handlebars/pull/20