### PR TITLE
Backport cdnify fix to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.10 (2018-05-09)
+-- Fix `cdnify` to avoid double slash in the genrated url [#141](https://github.com/bigcommerce/paper/pull/141) 
+
+## 2.0.9 (2018-08-14)
+-- Adds to `if` helper `gtnum` to determine greater than for numbers [#138](https://github.com/bigcommerce/paper/pull/138) 
+
 ## 2.0.8 (2018-05-09)
 - Add resourceHints and getFontLoaderConfig helpers [#133](https://github.com/bigcommerce/paper/pull/133)
 

--- a/index.js
+++ b/index.js
@@ -235,16 +235,20 @@ class Paper {
             return path;
         }
 
-        if (path[0] !== '/') {
-            path = '/' + path;
-        }
-
         if (!versionId) {
+            if (path[0] !== '/') {
+                path = '/' + path;
+            }
+            
             return path;
         }
 
-        if (path.match(/^\/assets\//)) {
-            path = path.substr(8, path.length);
+        if (path[0] === '/') {
+            path = path.slice(1, path.length);
+        }
+
+        if (path.match(/^assets\//)) {
+            path = path.substr(7, path.length);
         }
 
         if (sessionId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/test/helpers/if.js
+++ b/test/helpers/if.js
@@ -248,35 +248,35 @@ describe('if helper', () => {
         } catch(e) {
             expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
         }
-         try {
+        try {
             c('{{#if "2" "gtnum" num2}}big{{/if}}');
         } catch(e) {
             expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
         }
-         try {
+        try {
             c('{{#if num1 "gtnum" num2}}big{{/if}}');
         } catch(e) {
             expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
         }
-         done();
+        done();
     });
-     it('should throw an exeption when NaN value sent to gtnum', function (done) {
+    it('should throw an exeption when NaN value sent to gtnum', function (done) {
         try {
             c('{{#if "aaaa" "gtnum" "2"}}big{{/if}}');
         } catch(e) {
             expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
         }
-         try {
+        try {
             c('{{#if "2" "gtnum" "bbbb"}}big{{/if}}');
         } catch(e) {
             expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
         }
-         try {
+        try {
             c('{{#if "aaaa" "gtnum" "bbbb"}}big{{/if}}');
         } catch(e) {
             expect(e.message).to.equal('Handlerbars Helper if gtnum accepts ONLY valid number string');
         }
-         done();
+        done();
     });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,18 @@ describe('cdnify()', function () {
 
         done();
     });
+
+    it('should avoid double slash in path', function (done) {
+        var paper = new Paper({
+            cdn_url: 'http://cdn.example.com/foo',
+            theme_version_id: '123',
+        });
+
+        expect(paper.cdnify('img/icon-sprite.svg'))
+            .to.be.equal('http://cdn.example.com/foo/stencil/123/img/icon-sprite.svg');
+
+        done();
+    });
 });
 
 describe('render()', function() {


### PR DESCRIPTION
Backport cdnify fix in paper-handlebars 4.0.1 to the 2.x branch. Currently we are generating the cdn link for `img/icon-sprite.svg` with a double slash: `//img/icon-sprite.svg`. This fix avoids adding the extra slash.