### PR TITLE
Use http for font providers

### DIFF
--- a/helpers/resourceHints.js
+++ b/helpers/resourceHints.js
@@ -5,9 +5,8 @@ const getFonts = require('../lib/fonts');
 
 const fontResources = {
     'Google': [
-        '//ajax.googleapis.com',
-        '//fonts.googleapis.com',
-        '//fonts.gstatic.com',
+        'https://fonts.googleapis.com',
+        'https://fonts.gstatic.com',
     ],
 };
 

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -52,7 +52,7 @@ const fontProviders = {
         },
 
         buildLink: function(fonts) {
-            return '<link href="//fonts.googleapis.com/css?family=' + fonts.join('|') + '" rel="stylesheet">';
+            return '<link href="https://fonts.googleapis.com/css?family=' + fonts.join('|') + '" rel="stylesheet">';
         },
 
         buildFontLoaderConfig: function(fonts) {

--- a/test/helpers/getFontsCollection.js
+++ b/test/helpers/getFontsCollection.js
@@ -27,7 +27,7 @@ describe('fonts helper', function () {
         var template = "{{getFontsCollection}}";
 
         expect(c(template, themeSettings))
-            .to.be.equal('<link href="//fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|' +
+            .to.be.equal('<link href="https://fonts.googleapis.com/css?family=Open+Sans:,400italic,700|Karla:700|' +
             'Lora:400|Volkron:|Droid:400,700|Crimson+Text:400,700" rel="stylesheet">');
         done();
     });
@@ -42,7 +42,7 @@ describe('fonts helper', function () {
         var template = "{{getFontsCollection}}";
 
         expect(c(template, themeSettings))
-            .to.be.equal('<link href="//fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">');
+            .to.be.equal('<link href="https://fonts.googleapis.com/css?family=Open+Sans:" rel="stylesheet">');
         done();
     });
 });

--- a/test/helpers/resourceHints.js
+++ b/test/helpers/resourceHints.js
@@ -27,7 +27,7 @@ describe('resourceHints helper', function () {
         var template = "{{resourceHints}}";
 
         expect(c(template, themeSettings))
-            .to.be.equal('<link rel="dns-prefetch preconnect" href="//ajax.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="//fonts.gstatic.com" crossorigin>');
+            .to.be.equal('<link rel="dns-prefetch preconnect" href="https://fonts.googleapis.com" crossorigin><link rel="dns-prefetch preconnect" href="https://fonts.gstatic.com" crossorigin>');
         done();
     });
 });


### PR DESCRIPTION
Backport of paper-handlebars v4.0.3 to 2.x branch

* Update resourceHints to use https for font providers
* Update getFontsCollection to use https for font providers
