### PR TITLE
Bump paper-handlebars to 4.0.5 & Release v3.0.0-rc.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0-rc.11 (2019-2-14)
+- Bump paper-handlebars to 4.0.4 [#150](https://github.com/bigcommerce/paper/pull/150) to fix
+  regex performance to match precompiled templates.
+
 ## 3.0.0-rc.10 (2019-2-4)
 - Bump paper-handlebars to 4.0.4 [#149](https://github.com/bigcommerce/paper/pull/149) to fix  
   cdn url.
@@ -14,7 +18,7 @@
 
 ## 3.0.0-rc.7 (2018-10-30)
 - Bump paper-handlebars to 4.0.1 [#140](https://github.com/bigcommerce/paper/pull/140) to fix 
-  `cdnify` and avoid double slash in the genrated url.
+  `cdnify` and avoid double slash in the generated url.
 
 ## 3.0.0-rc.6 (2018-10-04)
 Breaking change:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.10",
+  "version": "3.0.0-rc.11",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "~4.0.4",
+    "@bigcommerce/stencil-paper-handlebars": "~4.0.5",
     "accept-language-parser": "~1.4.1",
     "lodash": "~3.10.1",
     "messageformat": "~0.2.2"


### PR DESCRIPTION
* Bump paper-handlebars to 4.0.5
* Release v3.0.0-rc.11

@bigcommerce/storefront-team @bigcommerce/platform-engineering 