### PR TITLE
Added option to pass logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0-rc.12 (2019-3-29)
+- Added an option to pass in logger and override the default logger of the app [#153](https://github.com/bigcommerce/paper/pull/153)
+
 ## 3.0.0-rc.11 (2019-2-14)
 - Bump paper-handlebars to 4.0.4 [#150](https://github.com/bigcommerce/paper/pull/150) to fix
   regex performance to match precompiled templates.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Translator = require('./lib/translator');
+const Logger = require('./lib/logger');
 const HandlebarsRenderer = require('@bigcommerce/stencil-paper-handlebars');
 
 /**
@@ -43,8 +44,9 @@ class Paper {
     * @param {assemblerGetTemplates} assembler.getTemplates - Method to assemble templates
     * @param {assemblerGetTranslations} assembler.getTranslations - Method to assemble translations
     * @param {String} rendererType - One of ['handlebars-v3', 'handlebars-v4']
+    * @param {Object} logger
     */
-    constructor(siteSettings, themeSettings, assembler, rendererType) {
+    constructor(siteSettings, themeSettings, assembler, rendererType, logger = Logger) {
         this._assembler = assembler || {};
 
         // Build renderer based on type
@@ -59,6 +61,8 @@ class Paper {
         }
 
         this.preProcessor = this.renderer.getPreProcessor();
+
+        this.logger = logger;
     }
 
     /**
@@ -184,7 +188,7 @@ class Paper {
      */
     loadTranslations(acceptLanguage) {
         return this._assembler.getTranslations().then(translations => {
-            const translator = Translator.create(acceptLanguage, translations);
+            const translator = Translator.create(acceptLanguage, translations, this.logger);
             this.renderer.setTranslator(translator);
             return translations;
         });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -23,4 +23,5 @@ function logError() {
 module.exports = {
     log: log,
     logError: logError,
+    error: logError,
 };

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -23,9 +23,12 @@ const DEFAULT_LOCALE = 'en';
  * @constructor
  * @param {string} acceptLanguage
  * @param {Object} allTranslations
+ * @param {Object} logger
  */
-function Translator(acceptLanguage, allTranslations) {
-    const languages = Transformer.transform(allTranslations, DEFAULT_LOCALE);
+function Translator(acceptLanguage, allTranslations, logger = Logger) {
+    this.logger = logger;
+
+    const languages = Transformer.transform(allTranslations, DEFAULT_LOCALE, this.logger);
 
     /**
      * @private
@@ -57,10 +60,11 @@ function Translator(acceptLanguage, allTranslations) {
  * @static
  * @param {string} acceptLanguage
  * @param {Object} allTranslations
+ * @param {Object} logger
  * @returns {Translator}
  */
-Translator.create = function (acceptLanguage, allTranslations) {
-    return new Translator(acceptLanguage, allTranslations);
+Translator.create = function (acceptLanguage, allTranslations, logger = Logger) {
+    return new Translator(acceptLanguage, allTranslations, logger);
 };
 
 /**
@@ -71,7 +75,6 @@ Translator.create = function (acceptLanguage, allTranslations) {
  */
 Translator.prototype.translate = function (key, parameters) {
     const language = this.getLanguage();
-
     if (!language.translations || !language.translations[key]) {
         return key;
     }
@@ -83,7 +86,7 @@ Translator.prototype.translate = function (key, parameters) {
     try {
         return this._formatFunctions[key](parameters);
     } catch (err) {
-        Logger.log(err);
+        this.logger.error(err);
 
         return '';
     }
@@ -136,7 +139,7 @@ Translator.prototype._compileTemplate = function (key) {
         return formatter.compile(language.translations[key]);
     } catch (err) {
         if (err.name === 'SyntaxError') {
-            Logger.logError(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
+            this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
 
             return () => '';
         }

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash');
 const AcceptLanguageParser = require('accept-language-parser');
-const Logger = require('../logger');
 const MessageFormat = require('messageformat');
 
 /**
@@ -55,8 +54,6 @@ function normalizeLocale(locale, defaultLocale) {
 
         return locale;
     } catch (err) {
-        Logger.log(err);
-
         return defaultLocale;
     }
 }

--- a/lib/translator/transformer.js
+++ b/lib/translator/transformer.js
@@ -11,23 +11,25 @@ const Logger = require('../logger');
  * Transform translations
  * @param {Object} allTranslations
  * @param {string} defaultLocale
+ * @param {Object} logger
  * @returns {Object.<string, Object>} Transformed translations
  */
-function transform(allTranslations, defaultLocale) {
-    return cascade(flatten(allTranslations), defaultLocale);
+function transform(allTranslations, defaultLocale, logger = Logger) {
+    return cascade(flatten(allTranslations, logger), defaultLocale);
 }
 
 /**
  * Flatten translations
  * @param {Object} allTranslations
+ * @param {Object} logger
  * @returns {Object.<string, Object>} Flatten translations
  */
-function flatten(allTranslations) {
+function flatten(allTranslations, logger = Logger) {
     return _.transform(allTranslations, (result, translation, locale) => {
         try {
             result[locale] = flattenObject(translation);
         } catch (err) {
-            Logger.log(`Failed to parse ${locale} - Error: ${err}`);
+            logger.error(`Failed to parse ${locale} - Error: ${err}`);
 
             result[locale] = {};
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.11",
+  "version": "3.0.0-rc.12",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -15,7 +15,6 @@ const it = lab.it;
 
 describe('Translator', () => {
     let errorLoggerStub;
-    let loggerStub;
     let translations;
 
     beforeEach(done => {
@@ -47,15 +46,13 @@ describe('Translator', () => {
             },
         };
 
-        errorLoggerStub = Sinon.stub(Logger, 'logError');
-        loggerStub = Sinon.stub(Logger, 'log');
+        errorLoggerStub = Sinon.stub(Logger, 'error');
 
         done();
     });
 
     afterEach(done => {
         errorLoggerStub.restore();
-        loggerStub.restore();
 
         done();
     });
@@ -109,7 +106,7 @@ describe('Translator', () => {
         const translator = Translator.create('nl', Object.assign({}, translations, { nl: nl }));
 
         expect(translator.translate('bye')).to.equal('Bye bye');
-        expect(loggerStub.called).to.equal(true);
+        expect(errorLoggerStub.called).to.equal(true);
 
         done();
     });
@@ -127,7 +124,7 @@ describe('Translator', () => {
         const translator = Translator.create('en', translations);
 
         expect(translator.translate('hello')).to.equal('');
-        expect(loggerStub.called).to.equal(true);
+        expect(errorLoggerStub.called).to.equal(true);
 
         done();
     });


### PR DESCRIPTION
The logger of this node module is only logging the error using console.log. This pr adds the option to pass logger. This is needed in case json log is needed (for ex. when the main app logging to logstash) 