### PR TITLE
Added option to pass logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.0.12 (2018-04-01)
+-- Added an option to pass in logger and override the default logger of the app [#155](https://github.com/bigcommerce/paper/pull/155)
 
 ## 2.0.11 (2018-12-19)
 -- Use https for font providers and resource hints [#144](https://github.com/bigcommerce/paper/pull/144)

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var Translator = require('./lib/translator');
+var Logger = require('./lib/logger');
 var Path = require('path');
 var Fs = require('fs');
 var Handlebars = require('handlebars');
@@ -69,9 +70,10 @@ Fs.readdirSync(Path.join(__dirname, 'helpers')).forEach(function (file) {
 * @param {Object} assembler - Assembler with getTemplates and getTranslations methods.
 * @param {assemblerGetTemplates} assembler.getTemplates - Method to assemble templates
 * @param {assemblerGetTranslations} assembler.getTranslations - Method to assemble translations
+* @param {Object} logger - optional, override the default logger
 */
 class Paper {
-    constructor(settings, themeSettings, assembler) {
+    constructor(settings, themeSettings, assembler, logger = Logger) {
         this.handlebars = Handlebars.create();
 
         this.handlebars.templates = {};
@@ -83,6 +85,7 @@ class Paper {
         this.themeSettings = themeSettings || {};
         this.assembler = assembler || {};
         this.contentServiceContext = {};
+        this.logger = logger;
 
         helpers.forEach(helper => helper(this));
     }
@@ -176,7 +179,7 @@ class Paper {
             }
 
             // Make translations available to the helpers
-            this.translator = Translator.create(acceptLanguage, translations);
+            this.translator = Translator.create(acceptLanguage, translations, this.logger);
 
             callback();
         });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -23,4 +23,5 @@ function logError() {
 module.exports = {
     log: log,
     logError: logError,
+    error: logError,
 };

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -23,9 +23,12 @@ const DEFAULT_LOCALE = 'en';
  * @constructor
  * @param {string} acceptLanguage
  * @param {Object} allTranslations
+ * @param {Object} logger
  */
-function Translator(acceptLanguage, allTranslations) {
-    const languages = Transformer.transform(allTranslations, DEFAULT_LOCALE);
+function Translator(acceptLanguage, allTranslations, logger = Logger) {
+    this.logger = logger;
+
+    const languages = Transformer.transform(allTranslations, DEFAULT_LOCALE, this.logger);
 
     /**
      * @private
@@ -58,9 +61,10 @@ function Translator(acceptLanguage, allTranslations) {
  * @param {string} acceptLanguage
  * @param {Object} allTranslations
  * @returns {Translator}
+ * @param {Object} logger
  */
-Translator.create = function (acceptLanguage, allTranslations) {
-    return new Translator(acceptLanguage, allTranslations);
+Translator.create = function (acceptLanguage, allTranslations, logger = Logger) {
+    return new Translator(acceptLanguage, allTranslations, logger);
 };
 
 /**
@@ -83,7 +87,7 @@ Translator.prototype.translate = function (key, parameters) {
     try {
         return this._formatFunctions[key](parameters);
     } catch (err) {
-        Logger.log(err);
+        this.logger.error(err);
 
         return '';
     }
@@ -136,7 +140,7 @@ Translator.prototype._compileTemplate = function (key) {
         return formatter.compile(language.translations[key]);
     } catch (err) {
         if (err.name === 'SyntaxError') {
-            Logger.logError(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
+            this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
 
             return () => '';
         }

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -6,7 +6,6 @@
 
 const _ = require('lodash');
 const AcceptLanguageParser = require('accept-language-parser');
-const Logger = require('../logger');
 const MessageFormat = require('messageformat');
 
 /**
@@ -55,8 +54,6 @@ function normalizeLocale(locale, defaultLocale) {
 
         return locale;
     } catch (err) {
-        Logger.log(err);
-
         return defaultLocale;
     }
 }

--- a/lib/translator/transformer.js
+++ b/lib/translator/transformer.js
@@ -12,22 +12,24 @@ const Logger = require('../logger');
  * @param {Object} allTranslations
  * @param {string} defaultLocale
  * @returns {Object.<string, Object>} Transformed translations
+ * @param {Object} logger
  */
-function transform(allTranslations, defaultLocale) {
-    return cascade(flatten(allTranslations), defaultLocale);
+function transform(allTranslations, defaultLocale, logger = Logger) {
+    return cascade(flatten(allTranslations, logger), defaultLocale);
 }
 
 /**
  * Flatten translations
  * @param {Object} allTranslations
  * @returns {Object.<string, Object>} Flatten translations
+ * @param {Object} logger
  */
-function flatten(allTranslations) {
+function flatten(allTranslations, logger = Logger) {
     return _.transform(allTranslations, (result, translation, locale) => {
         try {
             result[locale] = flattenObject(translation);
         } catch (err) {
-            Logger.log(`Failed to parse ${locale} - Error: ${err}`);
+            logger.error(`Failed to parse ${locale} - Error: ${err}`);
 
             result[locale] = {};
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -37,7 +37,7 @@
     "eslint-plugin-react": "^4.3.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0",
-    "lab": "^5.8.1",
+    "lab": "^13.0.1",
     "sinon": "^1.17.2"
   }
 }

--- a/test/lib/translator.spec.js
+++ b/test/lib/translator.spec.js
@@ -15,7 +15,6 @@ const it = lab.it;
 
 describe('Translator', () => {
     let errorLoggerStub;
-    let loggerStub;
     let translations;
 
     beforeEach(done => {
@@ -47,15 +46,13 @@ describe('Translator', () => {
             },
         };
 
-        errorLoggerStub = Sinon.stub(Logger, 'logError');
-        loggerStub = Sinon.stub(Logger, 'log');
+        errorLoggerStub = Sinon.stub(Logger, 'error');
 
         done();
     });
 
     afterEach(done => {
         errorLoggerStub.restore();
-        loggerStub.restore();
 
         done();
     });
@@ -109,7 +106,7 @@ describe('Translator', () => {
         const translator = Translator.create('nl', Object.assign({}, translations, { nl: nl }));
 
         expect(translator.translate('bye')).to.equal('Bye bye');
-        expect(loggerStub.called).to.equal(true);
+        expect(errorLoggerStub.called).to.equal(true);
 
         done();
     });
@@ -127,7 +124,7 @@ describe('Translator', () => {
         const translator = Translator.create('en', translations);
 
         expect(translator.translate('hello')).to.equal('');
-        expect(loggerStub.called).to.equal(true);
+        expect(errorLoggerStub.called).to.equal(true);
 
         done();
     });


### PR DESCRIPTION
The logger of this node module is only logging the error using console.log. This pr adds the option to pass logger. This is needed in case json log is needed (for ex. when the main app logging to logstash)