### PR TITLE
STRF-7011 release paper 2.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
--- Add getImageSrcset helper
--- Return image URLs as SafeString
+
+## 2.0.16 (2019-07-10)
+- Add getImageSrcset helper
+- Return image URLs as SafeString
 
 ## 2.0.15 (2019-06-30)
 -- Update handlebars to latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Update paper to 2.0.16 to get imageSrcset and responsive images out to the world.