### PR TITLE
Pull in paper-handlebars changes up to 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## 2.0.18 (2019-07-30)
+- Add setURLQueryParam helper
+- Make getImageSrcset not generate default srcsets larger than the original image when the dimensions are known
+- Make getImage not generate an image larger than the dimensions of the original image if the dimensions are known
+- Allow stripQuerystring to accept a Safestring as an argument
+- Refactor getImage helper to return image URL as SafeString instead of string
+
 ## 2.0.17 (2019-07-10)
 - Revert SafeString for getImage
 

--- a/helpers/getImage.js
+++ b/helpers/getImage.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+const SafeString = require('handlebars').SafeString;
 const common = require('./../lib/common');
 
 function helper(paper) {
@@ -23,17 +24,23 @@ function helper(paper) {
             // If preset is one of the given presets in _images
             width = parseInt(presets[presetName].width, 10) || 5120;
             height = parseInt(presets[presetName].height, 10) || 5120;
-            size = width + 'x' + height;
-
+            size = `${width}x${height}`;
         } else if (sizeRegex.test(settings[presetName])) {
             // If preset name is a setting and match the NNNxNNN format
             size = settings[presetName];
+            width = parseInt(size.split('x')[0], 10);
+            height = parseInt(size.split('x')[1], 10);
         } else {
             // Use the original image size
             size = 'original';
         }
 
-        return image.data.replace('{:size}', size);
+        if (Number.isInteger(image.width) && Number.isInteger(image.height)
+            && Number.isInteger(width) && Number.isInteger(height)) {
+            size = `${Math.min(image.width, width)}x${Math.min(image.height, height)}`
+        }
+
+        return new SafeString(image.data.replace('{:size}', size));
     });
 };
 

--- a/helpers/getImageSrcset.js
+++ b/helpers/getImageSrcset.js
@@ -26,16 +26,29 @@ function helper(paper) {
         let srcsets = {};
 
         if (options.hash['use_default_sizes']) {
-            srcsets = {
-                '2560w': '2560w',
-                '1920w': '1920w',
-                '1280w': '1280w',
-                '960w': '960w',
-                '640w': '640w',
-                '320w': '320w',
-                '160w': '160w',
-                '80w': '80w',
-            };
+            if (Number.isInteger(image.width) && Number.isInteger(image.height)){
+                /* If we know the image dimensions, don't generate srcset sizes larger than the image  */
+                srcsets[`${image.width}w`] = `${image.width}w`;
+                const defaultSrcsetSizes = [2560, 1920, 1280, 960, 640, 320, 160, 80];
+                defaultSrcsetSizes.forEach(width => {
+                    if (width < image.width) {
+                        srcsets[`${width}w`] = `${width}w`;
+                    }
+                });
+            } else {
+                /* If we DON'T know the image dimensions, generate a default set of srcsets
+                *  This will upsize images */
+                srcsets = {
+                    '2560w': '2560w',
+                    '1920w': '1920w',
+                    '1280w': '1280w',
+                    '960w': '960w',
+                    '640w': '640w',
+                    '320w': '320w',
+                    '160w': '160w',
+                    '80w': '80w',
+                };
+            }
         } else {
             srcsets = options.hash;
             if (!utils.isObject(srcsets) || Object.keys(srcsets).some(descriptor => {
@@ -55,6 +68,6 @@ function helper(paper) {
             return ([image.data.replace('{:size}', srcsets[descriptor]), descriptor].join(' '));
         }).join(', '));
     });
-};
+}
 
 module.exports = helper;

--- a/helpers/setURLQueryParam.js
+++ b/helpers/setURLQueryParam.js
@@ -1,0 +1,34 @@
+'use strict';
+const URL = require('url').URL;
+const utils = require('handlebars-utils');
+const common = require('./../lib/common');
+const SafeString = require('handlebars').SafeString;
+
+function helper(paper) {
+    paper.handlebars.registerHelper('setURLQueryParam', function(string, key, value) {
+        if (string instanceof SafeString) {
+            string = string.toString();
+        }
+        if (key instanceof SafeString) {
+            key = key.toString();
+        }
+        if (value instanceof SafeString) {
+            value = value.toString();
+        }
+        if (!utils.isString(string) || !common.isValidURL(string)){
+            throw new TypeError("Invalid URL passed to setURLQueryParam");
+        } else if (!utils.isString(key)){
+            throw new TypeError("Invalid query parameter key passed to setURLQueryParam");
+        } else if(!utils.isString(value)) {
+            throw new TypeError("Invalid query parameter value passed to setURLQueryParam");
+        }
+
+        const url = new URL(string);
+
+        url.searchParams.set(encodeURIComponent(key), encodeURIComponent(value));
+
+        return new SafeString(url.toString());
+    });
+}
+
+module.exports = helper;

--- a/helpers/stripQuerystring.js
+++ b/helpers/stripQuerystring.js
@@ -1,0 +1,16 @@
+'use strict';
+const SafeString = require('handlebars').SafeString;
+const utils = require('handlebars-utils');
+
+function helper(paper) {
+    paper.handlebars.registerHelper('stripQuerystring', function(url) {
+        if (url instanceof SafeString) {
+            url = url.toString();
+        }
+        if (utils.isString(url)) {
+            return url.split('?')[0];
+        }
+    });
+}
+
+module.exports = helper;

--- a/helpers/thirdParty.js
+++ b/helpers/thirdParty.js
@@ -138,7 +138,7 @@ const whitelist = [
     },
     {
         name: 'url',
-        include: ['encodeURI', 'decodeURI', 'urlResolve', 'urlParse', 'stripQuerystring', 'stripProtocol'],
+        include: ['encodeURI', 'decodeURI', 'urlResolve', 'urlParse', 'stripProtocol'],
     },
 ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/test/helpers/getImage.js
+++ b/test/helpers/getImage.js
@@ -33,7 +33,14 @@ describe('getImage helper', function() {
         image_url: 'http://example.com/image.png',
         not_an_image: null,
         image: {
-            data: urlData
+            data: urlData,
+            width: null,
+            height: null,
+        },
+        image_with_dimensions: {
+            data: urlData,
+            width: 123,
+            height: 123,
         },
         image_with_2_qs: {
             data: urlData_2_qs
@@ -66,13 +73,13 @@ describe('getImage helper', function() {
         expect(c('{{getImage image "logo"}}', context))
             .to.be.equal(urlData.replace('{:size}', '250x100'));
 
-        expect(c('{{{getImage image_with_2_qs "logo"}}}', context))
+        expect(c('{{getImage image_with_2_qs "logo"}}', context))
             .to.be.equal(urlData_2_qs.replace('{:size}', '250x100'));
 
         expect(c('{{getImage image "gallery"}}', context))
             .to.be.equal(urlData.replace('{:size}', '300x300'));
 
-        expect(c('{{{getImage image_with_2_qs "gallery"}}}', context))
+        expect(c('{{getImage image_with_2_qs "gallery"}}', context))
             .to.be.equal(urlData_2_qs.replace('{:size}', '300x300'));
 
         done();
@@ -112,6 +119,17 @@ describe('getImage helper', function() {
 
         expect(c('{{getImage image "missing_width"}}', context))
             .to.be.equal(urlData.replace('{:size}', '5120x100'));
+
+        done();
+    });
+
+    it('should default to size of the image dimensions if known and a larger size is requested', function(done) {
+
+        expect(c('{{getImage image_with_dimensions "logo"}}', context))
+            .to.be.equal(urlData.replace('{:size}', '123x100'));
+
+        expect(c('{{getImage image_with_dimensions "logo_image"}}', context))
+            .to.be.equal(urlData.replace('{:size}', '123x123'));
 
         done();
     });

--- a/test/helpers/getImageSrcset.js
+++ b/test/helpers/getImageSrcset.js
@@ -21,7 +21,14 @@ describe('getImageSrcset helper', function() {
             data: urlData
         },
         image_with_2_qs: {
-            data: urlData_2_qs
+            data: urlData_2_qs,
+            width: null,
+            height: null,
+        },
+        image_with_dimensions: {
+            data: urlData,
+            width: 1400,
+            height: 900,
         },
     };
 
@@ -38,6 +45,12 @@ describe('getImageSrcset helper', function() {
     it('should return a srcset made of default sizes if requested', function(done) {
         expect(c('{{getImageSrcset image use_default_sizes=true}}', context))
             .to.be.equal('https://cdn.example.com/path/to/80w/image.png?c=2 80w, https://cdn.example.com/path/to/160w/image.png?c=2 160w, https://cdn.example.com/path/to/320w/image.png?c=2 320w, https://cdn.example.com/path/to/640w/image.png?c=2 640w, https://cdn.example.com/path/to/960w/image.png?c=2 960w, https://cdn.example.com/path/to/1280w/image.png?c=2 1280w, https://cdn.example.com/path/to/1920w/image.png?c=2 1920w, https://cdn.example.com/path/to/2560w/image.png?c=2 2560w');
+        done();
+    });
+
+    it('should return a srcset made of default sizes up to the width of the image if known', function(done) {
+        expect(c('{{getImageSrcset image_with_dimensions use_default_sizes=true}}', context))
+            .to.be.equal('https://cdn.example.com/path/to/80w/image.png?c=2 80w, https://cdn.example.com/path/to/160w/image.png?c=2 160w, https://cdn.example.com/path/to/320w/image.png?c=2 320w, https://cdn.example.com/path/to/640w/image.png?c=2 640w, https://cdn.example.com/path/to/960w/image.png?c=2 960w, https://cdn.example.com/path/to/1280w/image.png?c=2 1280w, https://cdn.example.com/path/to/1400w/image.png?c=2 1400w');
         done();
     });
 

--- a/test/helpers/if.js
+++ b/test/helpers/if.js
@@ -242,7 +242,7 @@ describe('if helper', () => {
         done();
     });
 
-    it('should throw an exeption when non string value sent to gtnum', function (done) {
+    it('should throw an exception when non string value sent to gtnum', function (done) {
         try {
             c('{{#if num1 "gtnum" "2"}}big{{/if}}');
         } catch(e) {
@@ -260,7 +260,7 @@ describe('if helper', () => {
         }
         done();
     });
-    it('should throw an exeption when NaN value sent to gtnum', function (done) {
+    it('should throw an exception when NaN value sent to gtnum', function (done) {
         try {
             c('{{#if "aaaa" "gtnum" "2"}}big{{/if}}');
         } catch(e) {

--- a/test/helpers/setURLQueryParam.js
+++ b/test/helpers/setURLQueryParam.js
@@ -1,0 +1,89 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    var themeSettings = {};
+    return new Paper({}, themeSettings).loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('setURLQueryParam helper', function() {
+    const context = {
+        image_url: 'http://example.com/image.png',
+        not_a_url: null,
+        key: 'referrer',
+        value: 'google',
+    };
+
+    it('should return a URL with an added parameter given correct input', function(done) {
+        expect(c('{{setURLQueryParam "http://example.com/image.jpg" key value}}', context))
+            .to.be.equal(`http://example.com/image.jpg?${context.key}=${context.value}`);
+        expect(c('{{setURLQueryParam image_url "key" "value"}}', context))
+            .to.be.equal(`${context.image_url}?key=value`);
+        expect(c('{{setURLQueryParam (setURLQueryParam image_url "key" "value") "key2" "value2"}}', context))
+            .to.be.equal(`${context.image_url}?key=value&key2=value2`);
+        expect(c('{{setURLQueryParam "http://example.com/product-1?sku=abc123" "key" "value"}}', context))
+            .to.be.equal('http://example.com/product-1?sku=abc123&key=value');
+        done();
+    });
+
+    it('should return a URL with an updated parameter given correct input', function(done) {
+        expect(c('{{setURLQueryParam "http://example.com/image.jpg?c=2" "c" "3"}}', context))
+            .to.be.equal('http://example.com/image.jpg?c=3');
+        expect(c('{{setURLQueryParam "http://example.com/image.jpg?a=1&c=2" "c" "3"}}', context))
+            .to.be.equal('http://example.com/image.jpg?a=1&c=3');
+        expect(c('{{setURLQueryParam (setURLQueryParam "http://example.com/image.jpg?a=1&c=2" "a" "2") "c" "3"}}', context))
+            .to.be.equal('http://example.com/image.jpg?a=2&c=3');
+        expect(c('{{setURLQueryParam "http://example.com/product-1?sku=abc123" "sku" "def456"}}', context))
+            .to.be.equal('http://example.com/product-1?sku=def456');
+        done();
+    });
+
+    it('should throw an exception if a url is passed with no parameters', function (done) {
+        try {
+            c('{{setURLQueryParam "http://example.com/image.jpg"}}');
+        } catch(e) {
+        }
+        try {
+            c('{{setURLQueryParam urlData}}');
+        } catch(e) {
+        }
+        done();
+    });
+
+    it('should throw an exception if a url is passed with only one parameter', function (done) {
+        try {
+            c('{{setURLQueryParam "http://example.com/image.jpg" "key"}}');
+        } catch(e) {
+        }
+        try {
+            c('{{setURLQueryParam urlData key}}');
+        } catch(e) {
+        }
+        done();
+    });
+
+    it('should throw an exception if an invalid URL is passed', function (done) {
+        try {
+            c('{{setURLQueryParam not_a_url key value}}');
+        } catch(e) {
+        }
+        try {
+            c('{{setURLQueryParam not_a_url "key" "value"}}');
+        } catch(e) {
+        }
+        try {
+            c('{{setURLQueryParam "not_a_url" "key" "value"}}');
+        } catch(e) {
+        }
+        try {
+            c('{{setURLQueryParam "not_a_url" key value}}');
+        } catch(e) {
+        }
+        done();
+    });
+});

--- a/test/helpers/stripQuerystring.js
+++ b/test/helpers/stripQuerystring.js
@@ -1,0 +1,44 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    var themeSettings = {
+        logo_image: '600x300',
+    };
+    return new Paper({}, themeSettings).loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('stripQuerystring helper', function() {
+    const urlData_2_qs = 'https://cdn.example.com/path/to/{:size}/image.png?c=2&imbypass=on';
+    const context = {
+        image_with_2_qs: {
+            data: urlData_2_qs
+        },
+    };
+
+    it('strips the query string from a given url', function(done) {
+        expect(c('{{stripQuerystring "http://www.example.com?foo=1&bar=2&baz=3"}}', context))
+            .to.be.equal('http://www.example.com');
+
+        done();
+    });
+
+    it('should work with the getImageSrcset helper as a nested expression', function(done) {
+        expect(c('{{stripQuerystring (getImageSrcset image_with_2_qs 1x="100x100")}}', context))
+            .to.be.equal('https://cdn.example.com/path/to/100x100/image.png');
+
+        done();
+    });
+
+    it('should work with the getImage helper as a nested expression', function(done) {
+        expect(c('{{stripQuerystring (getImage image_with_2_qs "logo_image")}}', context))
+            .to.be.equal('https://cdn.example.com/path/to/600x300/image.png');
+
+        done();
+    });
+});

--- a/test/helpers/thirdParty.js
+++ b/test/helpers/thirdParty.js
@@ -203,18 +203,4 @@ describe('third party handlebars-helpers', function() {
         });
 
     });
-
-    describe('url helpers', function() {
-
-        describe('contains stripQuerystring', function() {
-            it('strips the query string from a given url', function(done) {
-                expect(c(`{{stripQuerystring 'http://www.example.com?foo=1&bar=2&baz=3'}}`, context))
-                    .to.be.equal('http://www.example.com');
-
-                done();
-            });
-        });
-
-    });
-    
 });


### PR DESCRIPTION
- Add setURLQueryParam helper
- Make getImageSrcset not generate default srcsets larger than the original image when the dimensions are known
- Make getImage not generate an image larger than the dimensions of the original image if the dimensions are known
- Make getImage return SafeString again
- Allow stripQuerystring to accept SafeString

Should mirror this changeset:

https://github.com/bigcommerce/paper-handlebars/compare/v4.1.1...v4.2.0