### PR TITLE
STRF-7393 bump paper-handlebars version to 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.0-rc.21 (2019-10-02)
+- Bump paper-handlebars version to 4.2.2 [#179](https://github.com/bigcommerce/paper/pull/179)
+
+## 3.0.0-rc.20 (2019-08-06)
+- Bump paper-handlebars to 4.2.1 [#177](https://github.com/bigcommerce/paper/pull/177)
+
 ## 3.0.0-rc.19 (2019-07-31)
 - Bump paper-handlebars to 4.2.0 [#175](https://github.com/bigcommerce/paper/pull/175)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.20",
+  "version": "3.0.0-rc.21",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "~4.2.1",
+    "@bigcommerce/stencil-paper-handlebars": "4.2.2",
     "accept-language-parser": "~1.4.1",
     "lodash": "~3.10.1",
     "messageformat": "~0.2.2"


### PR DESCRIPTION
This pr is part of a series of prs to upgrade cli to paper 3.x branch.

https://jira.bigcommerce.com/browse/STRF-7393

