### PR TITLE
bump paper to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0-rc.24 (2019-10-09)
+- Bump paper version [#182](https://github.com/bigcommerce/paper/pull/182)
+
 ## 3.0.0-rc.23 (2019-10-03)
 - Fix renderTheme function so that it may work with Stencil CLI [#181](https://github.com/bigcommerce/paper/pull/181)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.23",
+  "version": "3.0.0-rc.24",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Need to do a release on paper as git pull upstream master was not working properly and this caused an issue in stencil-cli where there was a diff in the code of the renderTheme function which is index.js of Paper.