### PR TITLE
STRF-7438 fix stencil language translation in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0-rc.26 (2019-10-16)
+- Fix Stencil language translation in Safari[#186](https://github.com/bigcommerce/paper/pull/186)
+
 ## 3.0.0-rc.25 (2019-10-15)
 - Bump paper-handlebars version to 4.2.3 [#183](https://github.com/bigcommerce/paper/pull/183)
 - Refactor logging. You can now pass an optional console-like logger object which will be used for internal logging as well as Handlebars logging. [#183](https://github.com/bigcommerce/paper/pull/183)

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -37,10 +37,17 @@ function getPreferredLocale(acceptLanguage, languages, defaultLocale) {
 function getLocales(acceptLanguage) {
     const localeObjects = AcceptLanguageParser.parse(acceptLanguage);
 
-    return _.map(localeObjects, localeObject => {
+    const locales = _.map(localeObjects, localeObject => {
         return _.isString(localeObject.region) ? `${localeObject.code}-${localeObject.region}` : localeObject.code;
     });
-}
+
+    //  Safari sends only one language code, this is to have a default fallback in case we don't have that language
+    //  As an example we may not have fr-FR so add fr to the header
+    if (locales.length === 1 && locales[0].split('-').length === 2) {
+        locales.push(locales[0].split('-')[0]);
+    }
+    return locales;
+ }
 
 /**
  * Normalize locale

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.25",
+  "version": "3.0.0-rc.26",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -62,6 +62,16 @@ describe('Translator', () => {
         done();
     });
 
+    it('should return translated strings in default language if it cannot find a translation file for a specified language', done => {
+        const translator = Translator.create('fr-FR', translations);
+
+        expect(translator.translate('bye')).to.equal('au revoir');
+        expect(translator.translate('hello', { name: 'Joe' })).to.equal('Bonjour Joe');
+        expect(translator.translate('level1.level2')).to.equal('nous sommes dans le deuxième niveau');
+
+        done();
+    });
+
     it('should return translated strings in English if cannot locate the preferred translation file', done => {
         const translator = Translator.create('es', translations);
 


### PR DESCRIPTION
This should fix the issue of Safari only sending the most preferred language's code.  If the most preferred language's code does not exist then we go to the fallback for that language such as fr-CA to fr.  If neither of these locales exist then we fallback to English.  Tested in safari browser.

https://jira.bigcommerce.com/browse/STRF-7438