### PR TITLE
Release 2.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 2.0.21 (2020-01-17)
+- Backport more permissive behavior of if helper in subexpressions[#190](https://github.com/bigcommerce/paper/pull/190)
+
 ## 2.0.20 (2019-10-22)
 - Fix Stencil language translation in Safari[#187](https://github.com/bigcommerce/paper/pull/187)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
## 2.0.21 (2020-01-17)
- Backport more permissive behavior of if helper in subexpressions[#190](https://github.com/bigcommerce/paper/pull/190)
