### PR TITLE
Update paper 2.x branch with encodeHtmlEntities helper and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 2.0.22 (2020-01-28)
+- Add encodeHtmlEntities helper
+
 ## 2.0.21 (2020-01-17)
 - Backport more permissive behavior of if helper in subexpressions[#190](https://github.com/bigcommerce/paper/pull/190)
 

--- a/helpers/encodeHtmlEntities.js
+++ b/helpers/encodeHtmlEntities.js
@@ -1,0 +1,18 @@
+'use strict';
+const he = require('he');
+const utils = require('handlebars-utils');
+const common = require('./../lib/common');
+const SafeString = require('handlebars').SafeString;
+
+function helper(paper) {
+    paper.handlebars.registerHelper('encodeHtmlEntities', function(string) {
+        string = common.unwrapIfSafeString(string);
+        if (!utils.isString(string)){
+            throw new TypeError("Non-string passed to encodeHtmlEntities");
+        }
+
+        return new SafeString(he.encode(string));
+    });
+}
+
+module.exports = helper;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "description": "A stencil plugin to register partials and helpers from handlebars and returns the compiled version for the stencil platform.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -26,6 +26,7 @@
     "handlebars": "3.0.7",
     "handlebars-helpers": "^0.8.0",
     "handlebars-utils": "^1.0.6",
+    "he": "^1.2.0",
     "lodash": "^3.6.0",
     "messageformat": "^0.2.2",
     "stringz": "^0.1.1",

--- a/test/helpers/encodeHtmlEntities.js
+++ b/test/helpers/encodeHtmlEntities.js
@@ -1,0 +1,33 @@
+var Code = require('code'),
+    Lab = require('lab'),
+    Paper = require('../../index'),
+    lab = exports.lab = Lab.script(),
+    describe = lab.experiment,
+    expect = Code.expect,
+    it = lab.it;
+
+function c(template, context) {
+    var themeSettings = {};
+    return new Paper({}, themeSettings).loadTemplatesSync({template: template}).render('template', context);
+}
+
+describe('encodeHtmlEntities helper', function() {
+    const context = {
+        string: 'foo © bar ≠ baz 𝌆 qux',
+        quotes: '"some" \'quotes\'',
+    };
+
+    it('should return a string with HTML entities encoded', function(done) {
+        expect(c('{{encodeHtmlEntities "foo © bar ≠ baz 𝌆 qux"}}', context))
+            .to.be.equal(`foo &#xA9; bar &#x2260; baz &#x1D306; qux`);
+        expect(c('{{encodeHtmlEntities string}}', context))
+            .to.be.equal(`foo &#xA9; bar &#x2260; baz &#x1D306; qux`);
+        expect(c('{{encodeHtmlEntities "string"}}', context))
+            .to.be.equal(`string`);
+        expect(c('{{encodeHtmlEntities quotes}}', context))
+            .to.be.equal('&#x22;some&#x22; &#x27;quotes&#x27;');
+        expect(c('{{encodeHtmlEntities "an ampersand: &"}}', context))
+            .to.be.equal('an ampersand: &#x26;');
+        done();
+    });
+});


### PR DESCRIPTION
Should match https://github.com/bigcommerce/paper-handlebars/pull/82 and https://github.com/bigcommerce/paper-handlebars/pull/83

ping @bigcommerce/storefront-team @lord2800 