### PR TITLE
update lodash to version 4

### DIFF
--- a/lib/translator/filter.js
+++ b/lib/translator/filter.js
@@ -15,7 +15,7 @@ const _ = require('lodash');
 function filterByKey(language, keyFilter) {
     return _.transform(language, (result, value, key) => {
         if (key === 'translations' || key === 'locales') {
-            result[key] = _.pick(value, (innerValue, innerKey) => innerKey.indexOf(keyFilter) === 0);
+            result[key] = _.pickBy(value, (innerValue, innerKey) => innerKey.indexOf(keyFilter) === 0);
         } else {
             result[key] = value;
         }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@bigcommerce/stencil-paper-handlebars": "4.3.1",
     "accept-language-parser": "~1.4.1",
-    "lodash": "~3.10.1",
+    "lodash": "^4.0.0",
     "messageformat": "~0.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates lodash to version 4.

A review of the code indicates that no other parts are affected by the breaking changes in the library update.