### PR TITLE
PEN-1911: Bump paper-handlebars and release rc31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0-rc.31 (2020-08-28)
+- Bump paper-handlebars version to 4.4.1 [#204](https://github.com/bigcommerce/paper/pull/204)
+
 ## 3.0.0-rc.30 (2020-08-25)
 - Bump paper-handlebars version to 4.4.0 [#202](https://github.com/bigcommerce/paper/pull/202)
 
@@ -13,7 +16,7 @@
 - Bump paper-handlebars version to 4.3.0 [#193](https://github.com/bigcommerce/paper/pull/193)
 
 ## 3.0.0-rc.26 (2019-10-16)
-- Fix Stencil language translation in Safari[#186](https://github.com/bigcommerce/paper/pull/186)
+- Fix Stencil language translation in Safari [#186](https://github.com/bigcommerce/paper/pull/186)
 
 ## 3.0.0-rc.25 (2019-10-15)
 - Bump paper-handlebars version to 4.2.3 [#183](https://github.com/bigcommerce/paper/pull/183)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.30",
+  "version": "3.0.0-rc.31",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.4.0",
+    "@bigcommerce/stencil-paper-handlebars": "4.4.1",
     "accept-language-parser": "~1.4.1",
     "lodash": "~3.10.1",
     "messageformat": "~0.2.2"


### PR DESCRIPTION
* Update paper-handlebars to 4.4.1 (contains handlebars 3.x and 4.x upgrades)
* Release rc31