### PR TITLE
feat: update ESLint to support newer JS syntax

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,14 +1,14 @@
 {
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2018, // suppport syntax features (like Object spread operator) up to es2018
     "sourceType": "module",
     "ecmaFeatures": {
       "impliedStrict": true
-    },
+    }
   },
   "env": {
     "node": true,
-    "es6": true,
+    "es2017": true // suppport globals (like Promise) up to es2017 (es2018 doesn't have new globals)
   },
   "rules": {
     "curly": 2,
@@ -22,6 +22,6 @@
     "dot-notation": 0,
     "no-debugger": 2,
     "no-undef": 2,
-    "no-unused-vars": [2, { "args": "none" }],
+    "no-unused-vars": [2, { "args": "none" }]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 8
   - 10
   - 12
   - 14

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ node_js:
   - 14
 script:
   - npm install
+  - npm run lint
   - npm test

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "author": "Bigcommerce",
   "license": "BSD-4-Clause",
   "scripts": {
-    "linter": "eslint .",
-    "test": "npm run linter && lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,FinalizationRegistry,WeakRef spec",
+    "lint": "eslint .",
+    "lint-and-fix": "eslint . --fix",
+    "test": "lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,FinalizationRegistry,WeakRef spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec"
   },
   "repository": {
@@ -29,7 +30,7 @@
   },
   "devDependencies": {
     "code": "~4.0.0",
-    "eslint": "~4.10.0",
+    "eslint": "^7.8.1",
     "lab": "~13.0.1",
     "sinon": "~7.5.0"
   }


### PR DESCRIPTION
## What? Why?

- Updated .eslintrc to support newer JS syntax (set es2018 which is fully supported by node 10).
- Updated the ESLInt to the last version.
- Removed Node 8 from .travis.yml since we don't support it on paper v3.x (and the last version of ESlint doesn't support Node 8 either)

## How was it tested?

`npm run linter`

cc: @bigcommerce/storefront-team
