### PR TITLE
BCTHEME-276 Escape values in inject helper

### DIFF
--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -5,8 +5,34 @@ function helper(paper) {
         if (typeof value === 'function') {
             return;
         }
+        function filterValues(value) {
+            let result = value;
+            try {
+                JSON.parse(value);
+            } catch (e) {
+                if (typeof value === 'string') {
+                    result = paper.handlebars.escapeExpression(value);
+                }
+                if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+                    result = filterObjectValues(value);
+                }
+                if (Array.isArray(value)) {
+                    result = value.map(item => {
+                        return filterValues(item);
+                    });
+                }
+            }
+            return result;
+        }
+        function filterObjectValues(obj) {
+            let filteredObject = {};
+            Object.keys(obj).forEach(key => {
+                filteredObject[key] = filterValues(obj[key]);
+            });
+            return filteredObject;
+        }
 
-        paper.inject[key] = value;
+        paper.inject[key] = filterValues(value);
     });
 
     paper.handlebars.registerHelper('jsContext', function () {

--- a/test/helpers/inject.js
+++ b/test/helpers/inject.js
@@ -11,9 +11,20 @@ function c(template, context) {
 }
 
 describe('inject helper', function() {
-    var context = {
+    const context = {
         value1: "Big",
         value2: "Commerce",
+        badChars: "&<>\"'`",
+        jsonString: JSON.stringify({"big": "commerce"}),
+        nested: {
+            firstName: "&<>",
+            lastName: "\"'`",
+            addresses: [
+                {
+                    street: "123 &<>\"'` St"
+                }
+            ],
+        },
     };
 
     it('should inject variables', function(done) {
@@ -23,5 +34,32 @@ describe('inject helper', function() {
             .to.be.equal('"{\\"data1\\":\\"Big\\",\\"data2\\":\\"Commerce\\"}"');
 
         done();
+    });
+
+    it('should escape strings', function(done) {
+        var template = "{{inject 'filtered' badChars}}{{jsContext}}";
+
+        expect(c(template, context))
+            .to.be.equal('"{\\"filtered\\":\\"&amp;&lt;&gt;&quot;&#x27;&#x60;\\"}"');
+        
+        done();
+    });
+
+    it('should exclude JSON strings from filtering', function(done) {
+        var template = "{{inject 'filtered' jsonString}}{{jsContext}}";
+
+        expect(c(template, context))
+            .to.be.equal('"{\\"filtered\\":\\"{\\\\\\"big\\\\\\":\\\\\\"commerce\\\\\\"}\\"}"');
+        
+        done();
+    });
+
+    it('should escape strings nested in objects and arrays', function(done) {
+        var template = "{{inject 'filtered' nested}}{{jsContext}}";
+
+        expect(c(template, context))
+            .to.be.equal('"{\\"filtered\\":{\\"firstName\\":\\"&amp;&lt;&gt;\\",\\"lastName\\":\\"&quot;&#x27;&#x60;\\",\\"addresses\\":[{\\"street\\":\\"123 &amp;&lt;&gt;&quot;&#x27;&#x60; St\\"}]}}"');
+        
+        done()
     });
 });


### PR DESCRIPTION
# What
Updating the inject helper in paper 2.x 

# Why
Stapler needs to have parity with the change to the inject helper in paper-handlebars that will be used by storefront-renderer.
See: https://github.com/bigcommerce/paper-handlebars/pull/110

# How was it tested?
Ran Stapler in my VM with my branch of Paper referenced, ensured values in jsContext were escaped the same way as in the PR above.

![image](https://user-images.githubusercontent.com/16565458/99008684-4147ec80-250c-11eb-8bcb-1bc47bb70880.png)


@bigcommerce/storefront-team 

