### PR TITLE
Switch paper to stable paper handlebar version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.5.0-rc.2",
+    "@bigcommerce/stencil-paper-handlebars": "4.4.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
4.5.x release of handlebar has a bug which needs to be fixed and it a rc candidate only.

@bigcommerce/storefront-team