### PR TITLE
chore: bump paper handlebars to 4.4.2 and release paper 3.0.0-rc.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 3.0.0-rc.34 (2020-09-21)
-- Bumps paper-handlebars to 4.4.1 [#208](https://github.com/bigcommerce/paper/pull/216)
+## 3.0.0-rc.35 (2020-11-17)
+- Bumps paper-handlebars to 4.4.2 [#208](https://github.com/bigcommerce/paper/pull/219)
+
+## 3.0.0-rc.34 (2020-11-16)
+- Rollback paper-handlebars to 4.4.1 [#208](https://github.com/bigcommerce/paper/pull/216)
 
 ## 3.0.0-rc.33 (2020-09-21)
 - Bumps paper-handlebars to 4.5.0-rc.2 [#208](https://github.com/bigcommerce/paper/pull/214)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.34",
+  "version": "3.0.0-rc.35",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.4.1",
+    "@bigcommerce/stencil-paper-handlebars": "4.4.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
@bigcommerce/storefront-team 