### PR TITLE
Release 3.0.0-rc.38 and paper handlebars 4.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0-rc.38 (2021-03-15)
+- Added public interface for handlebars to add templates and preprocess them [#228](https://github.com/bigcommerce/paper/pull/228)
+- Bumps paper-handlebars to 4.4.6 [#226](https://github.com/bigcommerce/paper/pull/229)
+
 ## 3.0.0-rc.37 (2021-02-12)
 - Bumps paper-handlebars to 4.4.4 [#226](https://github.com/bigcommerce/paper/pull/226)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.37",
+  "version": "3.0.0-rc.38",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.4.4",
+    "@bigcommerce/stencil-paper-handlebars": "4.4.6",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
Release 3.0.0-rc.38 and bump paper handlebars to 4.4.6