### PR TITLE
BCTHEME-276: Add option to escape values in inject helper

### DIFF
--- a/helpers/inject.js
+++ b/helpers/inject.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function helper(paper) {
-    paper.handlebars.registerHelper('inject', function (key, value) {
+    paper.handlebars.registerHelper('inject', function (key, value, escape) {
         if (typeof value === 'function') {
             return;
         }
@@ -31,8 +31,12 @@ function helper(paper) {
             });
             return filteredObject;
         }
+        
+        if (typeof escape === 'object') {
+            escape = false;
+        }
 
-        paper.inject[key] = filterValues(value);
+        paper.inject[key] = escape ? filterValues(value) : value;
     });
 
     paper.handlebars.registerHelper('jsContext', function () {

--- a/test/helpers/inject.js
+++ b/test/helpers/inject.js
@@ -7,7 +7,7 @@ var Code = require('code'),
     it = lab.it;
 
 function c(template, context) {
-    return new Paper().loadTemplatesSync({template: template}).render('template', context);
+    return new Paper().loadTemplatesSync({ template: template }).render('template', context);
 }
 
 describe('inject helper', function() {
@@ -15,7 +15,7 @@ describe('inject helper', function() {
         value1: "Big",
         value2: "Commerce",
         badChars: "&<>\"'`",
-        jsonString: JSON.stringify({"big": "commerce"}),
+        jsonString: JSON.stringify({ "big": "commerce" }),
         nested: {
             firstName: "&<>",
             lastName: "\"'`",
@@ -36,12 +36,12 @@ describe('inject helper', function() {
         done();
     });
 
-    it('should escape strings', function(done) {
-        var template = "{{inject 'filtered' badChars}}{{jsContext}}";
+    it('should escape strings when escape is set to true', function(done) {
+        var template = "{{inject 'filtered' badChars true}}{{jsContext}}";
 
         expect(c(template, context))
             .to.be.equal('"{\\"filtered\\":\\"&amp;&lt;&gt;&quot;&#x27;&#x60;\\"}"');
-        
+
         done();
     });
 
@@ -50,16 +50,34 @@ describe('inject helper', function() {
 
         expect(c(template, context))
             .to.be.equal('"{\\"filtered\\":\\"{\\\\\\"big\\\\\\":\\\\\\"commerce\\\\\\"}\\"}"');
-        
+
         done();
     });
 
-    it('should escape strings nested in objects and arrays', function(done) {
-        var template = "{{inject 'filtered' nested}}{{jsContext}}";
+    it('should escape strings nested in objects and arrays when escape is set to true', function(done) {
+        var template = "{{inject 'filtered' nested true}}{{jsContext}}";
 
         expect(c(template, context))
             .to.be.equal('"{\\"filtered\\":{\\"firstName\\":\\"&amp;&lt;&gt;\\",\\"lastName\\":\\"&quot;&#x27;&#x60;\\",\\"addresses\\":[{\\"street\\":\\"123 &amp;&lt;&gt;&quot;&#x27;&#x60; St\\"}]}}"');
-        
+
         done()
     });
+
+    it('should not escape characters by default', function(done) {
+        var template = "{{inject 'unfiltered' nested.firstName}}{{jsContext}}";
+
+        expect(c(template, context))
+            .to.be.equal('"{\\"unfiltered\\":\\"&<>\\"}"');
+
+        done();
+    })
+
+    it('should not escape characters when escape is set to false', function(done) {
+        var template = "{{inject 'unfiltered' nested.firstName false}}{{jsContext}}";
+
+        expect(c(template, context))
+            .to.be.equal('"{\\"unfiltered\\":\\"&<>\\"}"');
+
+        done();
+    })
 });


### PR DESCRIPTION
Similar to https://github.com/bigcommerce/paper-handlebars/pull/138

## What
Adding an optional param to the inject helper so developers can choose to escape injected values.

## Why
To prevent XSS when user-writeable fields are injected with the inject helper. By making this an optional argument, developers can opt in to escaping values, and existing theme customizations should not be impacted.

## Testing
Added tests and ran all unit tests
Started Stapler locally with this version of Paper and compared injected values in console log with custom Cornerstone.

