### PR TITLE
STRF-9112 langJson helper fix for non existent key and release version 42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
 # Changelog
 
+## 3.0.0-rc.42 (2021-05-11)
+- Improved filtering language object by key for langJSON helper, that was struggling with perfomance on GraalVM [#236](https://github.com/bigcommerce/paper/pull/236)
+
 ## 3.0.0-rc.41 (2021-05-07)
-- Improved filtering language object by key for langJSON helper, that was struggling with perfomance on GraalVM [#226](https://github.com/bigcommerce/paper/pull/234)
+- Improved filtering language object by key for langJSON helper, that was struggling with perfomance on GraalVM [#234](https://github.com/bigcommerce/paper/pull/234)
 
 ## 3.0.0-rc.40 (2021-03-30)
-- paper.loadTranslations now supports additional parameter to omit transforming translations [#226](https://github.com/bigcommerce/paper/pull/231)
+- paper.loadTranslations now supports additional parameter to omit transforming translations [#231](https://github.com/bigcommerce/paper/pull/231)
 
 ## 3.0.0-rc.39 (2021-03-15)
-- Bumps paper-handlebars to 4.4.7 [#226](https://github.com/bigcommerce/paper/pull/230)
+- Bumps paper-handlebars to 4.4.7 [#230](https://github.com/bigcommerce/paper/pull/230)
 
 ## 3.0.0-rc.38 (2021-03-15)
 - Added public interface for handlebars to add templates and preprocess them [#228](https://github.com/bigcommerce/paper/pull/228)
-- Bumps paper-handlebars to 4.4.6 [#226](https://github.com/bigcommerce/paper/pull/229)
+- Bumps paper-handlebars to 4.4.6 [#229](https://github.com/bigcommerce/paper/pull/229)
 
 ## 3.0.0-rc.37 (2021-02-12)
 - Bumps paper-handlebars to 4.4.4 [#226](https://github.com/bigcommerce/paper/pull/226)

--- a/lib/translator/filter.js
+++ b/lib/translator/filter.js
@@ -17,12 +17,10 @@ function filterByKey(language, keyFilter) {
         const key = languageKeys[i];
         if (key === 'translations' || key === 'locales') {
             const languageSubKeys = Object.keys(language[key]);
+            result[key] = {};
             for (let k = 0; k < languageSubKeys.length; k++) {
                 const subKey = languageSubKeys[k];
                 if (subKey.startsWith(keyFilter)) {
-                    if (!result[key]) {
-                        result[key] = {};
-                    }
                     result[key][subKey] = language[key][subKey];
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.41",
+  "version": "3.0.0-rc.42",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -259,6 +259,12 @@ describe('Translator', () => {
             },
         });
 
+        expect(translator.getLanguage('non-existent')).to.equal({
+            locale: 'en',
+            locales: {},
+            translations: {},
+        });
+
         done();
     });
 


### PR DESCRIPTION
There is a bug with getting a translation for non existent key. It should return an empty object

сс @bigcommerce/storefront-team 