### PR TITLE
STRF-9219 Fix Polyglot exceptions for precompileTranslations

### DIFF
--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -23,10 +23,12 @@ const DEFAULT_LOCALE = 'en';
  * @param {Object} allTranslations
  * @param {Object} logger
  * @param {Boolean} omitTransforming
+ * @param {Boolean} disablePluralKeyChecks
  */
-function Translator(acceptLanguage, allTranslations, logger = console, omitTransforming = false) {
+function Translator(acceptLanguage, allTranslations, logger = console, omitTransforming = false, disablePluralKeyChecks = true) {
     this.logger = logger;
     this.omitTransforming = omitTransforming;
+    this.disablePluralKeyChecks = disablePluralKeyChecks;
 
     const languages = this.omitTransforming ? allTranslations : Transformer.transform(allTranslations, DEFAULT_LOCALE, this.logger);
     /**
@@ -95,7 +97,8 @@ Translator.create = function (acceptLanguage, allTranslations, logger = console,
  */
 Translator.compileFormatterFunction = function (language, key) {
     const locale = language.locales[key];
-    const formatter = new MessageFormat(locale)
+    const formatter = new MessageFormat(locale);
+    formatter.disablePluralKeyChecks();
 
     try {
         return formatter.compile(language.translations[key]).toString();
@@ -109,6 +112,28 @@ Translator.compileFormatterFunction = function (language, key) {
         throw err;
     }
 }
+
+Translator.prototype.areFormatterFunctionsGlobal = function() {
+    if (typeof global === "undefined") {
+        return true;
+    }
+
+    return global.plural;
+}
+
+Translator.prototype.enableFormatterFunctionsGlobalScope = function() {
+    const mf = new MessageFormat(this._locale);
+    global.plural = mf.runtime.plural;
+    global[this._locale] = mf.pluralFuncs[this._locale];
+    global.number = mf.runtime.number;
+    global.select = mf.runtime.select;
+};
+
+Translator.prototype.checkFormatterFunctionsAvailability = function() {
+    if (!this.areFormatterFunctionsGlobal()) {
+        this.enableFormatterFunctionsGlobalScope();
+    }
+};
 
 /**
  * Get translated string
@@ -128,6 +153,7 @@ Translator.prototype.translate = function (key, parameters) {
 
     try {
         if (this.omitTransforming) {
+            this.checkFormatterFunctionsAvailability();
             const fn = new Function(`return ${language.compiledTranslations[key]}`)()
             return fn(parameters);
         }
@@ -176,7 +202,13 @@ Translator.prototype.setLanguage = function (languages) {
  * @returns {MessageFormat} Return cached or new MessageFormat
  */
 Translator.prototype._getFormatter = function (locale) {
-    this._formatters[locale] = this._formatters[locale] || new MessageFormat(locale);
+    if (!this._formatters[locale]) {
+        this._formatters[locale] = new MessageFormat(locale);
+        if (this.disablePluralKeyChecks) {
+            this._formatters[locale].disablePluralKeyChecks();
+        }
+    }
+   
 
     return this._formatters[locale];
 };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint-and-fix": "eslint . --fix",
-    "test": "lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,FinalizationRegistry,WeakRef spec",
+    "test": "lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,FinalizationRegistry,WeakRef,plural,en,number,select spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec"
   },
   "repository": {

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -328,6 +328,27 @@ describe('Translator', () => {
             done();
         })
 
+        it('should not throw an error on compiling translation', done => {
+            const flattenedLanguages = {
+                "en": {
+                  "locale": "en",
+                  "locales": {
+                    "items": "en",
+                  },
+                  "translations": {
+                    "items": "{count, plural, zero{No results} one{# result} other{# results}} found for {term}",
+                  }
+                }
+            };
+            const locale = 'en';
+            const translator = Translator.create(locale, flattenedLanguages, console, true);
+            const precompiledTranslations = Translator.precompileTranslations(flattenedLanguages);
+            translator.setLanguage(precompiledTranslations)
+            const result = translator.translate('items', {count: 0, term: 'product'});
+            expect(result).to.equal('0 results found for product');
+
+            done();
+        })
     })
 
 });


### PR DESCRIPTION
1. Introduce option disablePluralKeyChecks
2. Before version 2 messageformat was ignoring if the keys in the message are wrong, now it throws an error. disablePluralKeyChecks() function is used to disable that check
3. Some messageformat methods(plurals, select, etc.), that are used in precompiling templates are not in the global scope, so  added them to the global scope

cc @junedkazi @jmwiese @pachanady 