### PR TITLE
STRF-9227 Address Polyglot exceptions

### DIFF
--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -101,15 +101,16 @@ Translator.compileFormatterFunction = function (language, key) {
     formatter.disablePluralKeyChecks();
 
     try {
-        return formatter.compile(language.translations[key]).toString();
+        const value = typeof language.translations[key] === "string"
+            ? language.translations[key]
+            : language.translations[key].toString();
+        return formatter.compile(value).toString();
     } catch (err) {
-        if (err.name === 'SyntaxError') {
-            this.logger.error(`Syntax Error during Formatter function precompilation: ${err.message} for key "${key}"`, err.expected);
+        console.error(`Error occured during Formatter function precompilation: ${err.message} for key "${key}"`);
 
-            return () => '';
-        }
-
-        throw err;
+        const value = language.translations[key] ? language.translations[key] : key;
+        const fn = new Function(`return "${value}"`);
+        return fn.toString();
     }
 }
 

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -349,6 +349,31 @@ describe('Translator', () => {
 
             done();
         })
+
+        it('should log error and return key', done => {
+            const flattenedValue = "Calificado {rating, plural, one {# Star} otro {# Stars}} O Mas";
+            const flattenedLanguages = {
+                "es": {
+                  "locale": "es",
+                  "locales": {
+                    "items": "es",
+                  },
+                  "translations": {
+                    "items": flattenedValue,
+                  }
+                }
+            };
+            const locale = 'es';
+            const translator = Translator.create(locale, flattenedLanguages, console, true);
+            const precompiledTranslations = Translator.precompileTranslations(flattenedLanguages);
+            translator.setLanguage(precompiledTranslations)
+            const result = translator.translate('items', {rating: 10});
+
+            expect(result).to.equal(flattenedValue);
+
+            done();
+
+        });
     })
 
 });


### PR DESCRIPTION
1) In case if translation key is not string, we try to set it to string.
2) Do not break render operation if some translation key is not possible to precompile because of wrongly formatted (or other reason)

cc @bigcommerce/storefront-team 