### PR TITLE
MERC-7830 region name localization support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.4.7",
+    "@bigcommerce/stencil-paper-handlebars": "4.4.8",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~2.3.0"
   },


### PR DESCRIPTION
Note, but build should pass once `paper-handlebars` PR has been merged and released. Currently build is failing to install packages as I am using a remote url for `paper-handlebars` package.

## Dependencies
- [x] [Paper-handlebars](https://github.com/bigcommerce/paper-handlebars/pull/140): PR to allow adding `data-content-region-translation` attribute
- [ ] Paper (This PR): Update to `paper-handlebars` version to support new data attribute
- [ ] [Storefront-renderer](https://github.com/bigcommerce/storefront-renderer/pull/280): Update to `paper` version to support new parsing of region translations 
- [ ] [Stencil-cli](https://github.com/bigcommerce/stencil-cli/pull/731): Update to stencil cli to parse `translation` from theme and generate manifest with new translation data. 
- [ ] [Page builder](https://github.com/bigcommerce/store-design/pull/1101) = Add support to use the correct translation if provided from schemaTranslations. 


## What? Why?
Region name localization support. This PR is to add `content-region-translation` data attribute if translation is provided in the html handlebars from the theme. This will be used to surface the correct translation on the front end (page builder) for a particular region.

<img width="1680" alt="Screen Shot 2021-07-06 at 11 48 34 AM" src="https://user-images.githubusercontent.com/33278039/124653678-71088380-de52-11eb-84f4-d63d36dd9521.png">
<img width="1680" alt="Screen Shot 2021-07-06 at 11 47 45 AM" src="https://user-images.githubusercontent.com/33278039/124653673-6f3ec000-de52-11eb-91f3-e022379c6fcf.png">


## How was it tested?
Steps to test 

(1) Pull down the `storefront-render` [PR](https://github.com/bigcommerce/storefront-renderer/pull/280) and run locally (or can run the container image) 

(2) Pull down `stencil-cli` [PR](https://github.com/bigcommerce/stencil-cli/pull/731) and create theme with `{{{region name="header_bottom" translation="i18n.RegionName.HeaderBottom"}}}` and `i18n.RegionName.HeaderBottom` dummy translation within `schema.json`. **EXAMPLE PROVIDED BELOW**

(3) Change store language to non english language (`chinese` and `french` example provided)

(4) Upload test theme, load page builder and load layers pane to see the correct language.

Example Region + Schema.json

**Region**
`{{{region name="header_bottom" translation="i18n.RegionName.HeaderBottom"}}}`

**Schema.json**
```
  "i18n.RegionName.HeaderBottom": {
    "default": "Header Bottom",
    "en": "Header Bottom",
    "fr-FR": "Bas de l'en-tête",
    "zh": "标题底部",
    "zh-CN": "标题底部"
  }
```


cc @bigcommerce/storefront-team
