### PR TITLE
STRF-9222 Replace/upgrade deprecated messageformat library

### DIFF
--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -4,7 +4,8 @@
  * @module paper/lib/translator
  */
 
-const MessageFormat = require('messageformat');
+const MessageFormat = require('@messageformat/core');
+const { plural } = require('@messageformat/runtime');
 const Filter = require('./filter');
 const LocaleParser = require('./locale-parser');
 const Transformer = require('./transformer');
@@ -23,12 +24,10 @@ const DEFAULT_LOCALE = 'en';
  * @param {Object} allTranslations
  * @param {Object} logger
  * @param {Boolean} omitTransforming
- * @param {Boolean} disablePluralKeyChecks
  */
-function Translator(acceptLanguage, allTranslations, logger = console, omitTransforming = false, disablePluralKeyChecks = true) {
+function Translator(acceptLanguage, allTranslations, logger = console, omitTransforming = false) {
     this.logger = logger;
     this.omitTransforming = omitTransforming;
-    this.disablePluralKeyChecks = disablePluralKeyChecks;
 
     const languages = this.omitTransforming ? allTranslations : Transformer.transform(allTranslations, DEFAULT_LOCALE, this.logger);
     /**
@@ -98,7 +97,6 @@ Translator.create = function (acceptLanguage, allTranslations, logger = console,
 Translator.compileFormatterFunction = function (language, key) {
     const locale = language.locales[key];
     const formatter = new MessageFormat(locale);
-    formatter.disablePluralKeyChecks();
 
     try {
         const value = typeof language.translations[key] === "string"
@@ -123,11 +121,7 @@ Translator.prototype.areFormatterFunctionsGlobal = function() {
 }
 
 Translator.prototype.enableFormatterFunctionsGlobalScope = function() {
-    const mf = new MessageFormat(this._locale);
-    global.plural = mf.runtime.plural;
-    global[this._locale] = mf.pluralFuncs[this._locale];
-    global.number = mf.runtime.number;
-    global.select = mf.runtime.select;
+    global.plural = plural;
 };
 
 Translator.prototype.checkFormatterFunctionsAvailability = function() {
@@ -205,9 +199,6 @@ Translator.prototype.setLanguage = function (languages) {
 Translator.prototype._getFormatter = function (locale) {
     if (!this._formatters[locale]) {
         this._formatters[locale] = new MessageFormat(locale);
-        if (this.disablePluralKeyChecks) {
-            this._formatters[locale].disablePluralKeyChecks();
-        }
     }
    
 
@@ -227,13 +218,9 @@ Translator.prototype._compileTemplate = function (key) {
     try {
         return formatter.compile(language.translations[key]);
     } catch (err) {
-        if (err.name === 'SyntaxError') {
-            this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
+        this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
 
-            return () => '';
-        }
-
-        throw err;
+        return () => ''
     }
 };
 

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -4,7 +4,7 @@
  * @module paper/lib/translator/locale-parser
  */
 const AcceptLanguageParser = require('accept-language-parser');
-const MessageFormat = require('messageformat');
+const MessageFormat = require('@messageformat/core');
 
 /**
  * Get preferred locale
@@ -15,14 +15,13 @@ const MessageFormat = require('messageformat');
  */
 function getPreferredLocale(acceptLanguage, languages, defaultLocale) {
     const locale = getLocales(acceptLanguage).find(locale => languages[locale]) || defaultLocale;
-
-    try {
-        new MessageFormat(locale);
-
-        return locale;
-    } catch (err) {
+    const mf = new MessageFormat(locale);
+    const options = mf.resolvedOptions();
+    if (options.locale === MessageFormat.defaultLocale) {
         return defaultLocale;
     }
+
+    return locale;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
     "@bigcommerce/stencil-paper-handlebars": "4.4.8",
-    "accept-language-parser": "~1.4.1",
-    "messageformat": "~2.3.0"
+    "@messageformat/core": "^3.0.0",
+    "accept-language-parser": "~1.4.1"
   },
   "devDependencies": {
     "code": "~4.0.0",

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -142,8 +142,8 @@ describe('Translator', () => {
             },
         }, loggerStub);
 
-        translator.translate('items_with_syntax_error', { count: 1 });
-
+        const result = translator.translate('items_with_syntax_error', { count: 1 });
+        expect(result).to.equal("");
         expect(loggerStub.error.called).to.equal(true);
 
         done();
@@ -156,7 +156,8 @@ describe('Translator', () => {
             },
         });
 
-        expect(() => translator.translate('gender_error', { gender: 'shemale' })).to.throw(Error);
+        const result = translator.translate('gender_error', { gender: 'shemale' });
+        expect(result).to.equal("");
 
         done();
     });
@@ -328,7 +329,7 @@ describe('Translator', () => {
             done();
         })
 
-        it('should not throw an error on compiling translation', done => {
+        it('should not throw an error on compiling translation (zero key is invalid for locale=en', done => {
             const flattenedLanguages = {
                 "en": {
                   "locale": "en",
@@ -345,7 +346,7 @@ describe('Translator', () => {
             const precompiledTranslations = Translator.precompileTranslations(flattenedLanguages);
             translator.setLanguage(precompiledTranslations)
             const result = translator.translate('items', {count: 0, term: 'product'});
-            expect(result).to.equal('0 results found for product');
+            expect(result).to.equal('{count, plural, zero{No results} one{# result} other{# results}} found for {term}');
 
             done();
         })


### PR DESCRIPTION
1. Removed **disablePluralKeyChecks** option as it's not supported anymore
2. "Zero" key is invalid for lang "en". (https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html)
Before library was ignoring it, now it throws an error. In cornerstone we don't have it (https://github.com/bigcommerce/cornerstone/blob/master/lang/en.json), but other developers might have it.
3. There is change in **lang** helper logic. Before it was throwing a SyntaxError if there is some "syntax error", now it always a generic Error. So the idea is to throw an error always when the value is invalid and log a message. 

cc @bookernath, @bigcommerce/storefront-team 