### PR TITLE
Release version 3.0.0-rc.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0-rc.47 (2021-06-17)
+- Bump paper-handlebars to latest version, includes changes to support region translations [#245](https://github.com/bigcommerce/paper/pull/245)
+
 ## 3.0.0-rc.46 (2021-06-17)
 - Do not break render operation if some translation key is not possible to precompile because of wrongly formatted value [#243](https://github.com/bigcommerce/paper/pull/243)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.46",
+  "version": "3.0.0-rc.47",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Release version 3.0.0-rc.47.

Bump paper handlebars version to latest, includes changes to support region translations