### PR TITLE
STRF-9273 Moving MessageFormat creation to try/catch block to supress  errors on backup lang files

### DIFF
--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -96,9 +96,9 @@ Translator.create = function (acceptLanguage, allTranslations, logger = console,
  */
 Translator.compileFormatterFunction = function (language, key) {
     const locale = language.locales[key];
-    const formatter = new MessageFormat(locale);
 
     try {
+        const formatter = new MessageFormat(locale);
         const value = typeof language.translations[key] === "string"
             ? language.translations[key]
             : language.translations[key].toString();


### PR DESCRIPTION
We've seen people are creating 'en copy', 'en.json.bak' and 'en.json.orig' files to backup their original translation copy. This can fail to an error while translations precompilation happens