### PR TITLE
Release 3.0.0-rc.49

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '10.x'
-      - run: npm ci
+      - run: npm i
       # Setup .npmrc file to publish to npm registry
       - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
       - run: npm publish --tag=beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0-rc.49 (2021-09-16)
+- Bumps paper-handlebars to 4.4.9 [#252](https://github.com/bigcommerce/paper/pull/252)
+
 ## 3.0.0-rc.48 (2021-07-20)
 - Upgrade deprecated messageformat library to @messageformat/core [#246](https://github.com/bigcommerce/paper/pull/246)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.0-rc.48",
+  "version": "3.0.0-rc.49",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.4.8",
+    "@bigcommerce/stencil-paper-handlebars": "4.4.9",
     "@messageformat/core": "^3.0.0",
     "accept-language-parser": "~1.4.1"
   },


### PR DESCRIPTION
 - Bumps paper-handlebars to 4.4.9 [#252](https://github.com/bigcommerce/paper/pull/252)
 - Release paper package through Github Actions [#251](https://github.com/bigcommerce/paper/pull/251)