### PR TITLE
STRF-9379 Revert messageformat to pre-GraalVM condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,12 +182,11 @@ class Paper {
      * Load translation files and give a translator to renderer.
      *
      * @param {String} acceptLanguage The accept-language header, used to select a locale
-     * @param {Boolean} omitTransforming If set to true, translations won't be transformted(flattened) and used as provided
      * @return {Promise} Promise to load the translations into the renderer.
      */
-    loadTranslations(acceptLanguage, omitTransforming = false) {
+    loadTranslations(acceptLanguage) {
         return this._assembler.getTranslations().then(translations => {
-            const translator = Translator.create(acceptLanguage, translations, this.logger, omitTransforming);
+            const translator = Translator.create(acceptLanguage, translations, this.logger);
             this.renderer.setTranslator(translator);
             return translations;
         });
@@ -288,15 +287,6 @@ class Paper {
      */
     addTemplates(templates) {
         this.renderer.addTemplates(templates);
-    }
-
-    /**
-     * Precompiles translations to string representations of translation function source code 
-     * 
-     * @param {Object} translations transformed translations object 
-     */
-    precompileTranslations(translations) {
-        return Translator.precompileTranslations(translations);
     }
 }
 

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -4,8 +4,7 @@
  * @module paper/lib/translator
  */
 
-const MessageFormat = require('@messageformat/core');
-const { plural } = require('@messageformat/runtime');
+const MessageFormat = require('messageformat');
 const Filter = require('./filter');
 const LocaleParser = require('./locale-parser');
 const Transformer = require('./transformer');
@@ -57,36 +56,12 @@ function Translator(acceptLanguage, allTranslations, logger = console, omitTrans
  * @param {string} acceptLanguage
  * @param {Object} allTranslations
  * @param {Object} logger
- * @param {Boolean} omitTransforming
  * @returns {Translator}
  */
-Translator.create = function (acceptLanguage, allTranslations, logger = console, omitTransforming = false) {
-    return new Translator(acceptLanguage, allTranslations, logger, omitTransforming);
+Translator.create = function (acceptLanguage, allTranslations, logger = console) {
+    return new Translator(acceptLanguage, allTranslations, logger);
 };
 
-/**
- * Precompile translation functions
- * @param {Object} translations
- * @returns {Object}
- */
- Translator.precompileTranslations = function (translations) {
-    const compiled = {};
-
-    Object.keys(translations).forEach(language => {
-        compiled[language] = {}
-        Object.keys(translations[language]).forEach(categoryKey => {
-            compiled[language][categoryKey] = translations[language][categoryKey];
-            if (categoryKey === 'translations') {
-                compiled[language].compiledTranslations = {};
-                Object.keys(translations[language][categoryKey]).forEach(key => {
-                    compiled[language].compiledTranslations[key] = Translator.compileFormatterFunction(translations[language], key);
-                })
-            }
-        });
-    });
-
-    return compiled;
-}
 
 /**
  * Precompile translation functions
@@ -112,23 +87,6 @@ Translator.compileFormatterFunction = function (language, key) {
     }
 }
 
-Translator.prototype.areFormatterFunctionsGlobal = function() {
-    if (typeof global === "undefined") {
-        return true;
-    }
-
-    return global.plural;
-}
-
-Translator.prototype.enableFormatterFunctionsGlobalScope = function() {
-    global.plural = plural;
-};
-
-Translator.prototype.checkFormatterFunctionsAvailability = function() {
-    if (!this.areFormatterFunctionsGlobal()) {
-        this.enableFormatterFunctionsGlobalScope();
-    }
-};
 
 /**
  * Get translated string
@@ -142,17 +100,11 @@ Translator.prototype.translate = function (key, parameters) {
         return key;
     }
 
-    if (!this.omitTransforming && typeof this._formatFunctions[key] === 'undefined') {
+    if (typeof this._formatFunctions[key] === 'undefined') {
         this._formatFunctions[key] = this._compileTemplate(key);
     }
 
     try {
-        if (this.omitTransforming) {
-            this.checkFormatterFunctionsAvailability();
-            const fn = new Function(`return ${language.compiledTranslations[key]}`)()
-            return fn(parameters);
-        }
-    
         return this._formatFunctions[key](parameters);
     } catch (err) {
         this.logger.error(err);

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -4,7 +4,7 @@
  * @module paper/lib/translator/locale-parser
  */
 const AcceptLanguageParser = require('accept-language-parser');
-const MessageFormat = require('@messageformat/core');
+const MessageFormat = require('messageformat');
 
 /**
  * Get preferred locale
@@ -15,13 +15,13 @@ const MessageFormat = require('@messageformat/core');
  */
 function getPreferredLocale(acceptLanguage, languages, defaultLocale) {
     const locale = getLocales(acceptLanguage).find(locale => languages[locale]) || defaultLocale;
-    const mf = new MessageFormat(locale);
-    const options = mf.resolvedOptions();
-    if (options.locale === MessageFormat.defaultLocale) {
+    try {
+        new MessageFormat(locale);
+
+        return locale;
+    } catch (err) {
         return defaultLocale;
     }
-
-    return locale;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
     "@bigcommerce/stencil-paper-handlebars": "4.4.9",
-    "@messageformat/core": "^3.0.0",
-    "accept-language-parser": "~1.4.1"
+    "accept-language-parser": "~1.4.1",
+    "messageformat": "~0.2.2"
   },
   "devDependencies": {
     "code": "~4.0.0",

--- a/spec/index.js
+++ b/spec/index.js
@@ -187,32 +187,4 @@ describe('loadTranslations', () => {
             done();
         });
     });
-
-    it('should load translations and omit trasnformation', done => {
-        const assembler = {
-            getTemplates: () => Promise.resolve({}),
-            getTranslations: () => {
-                return Promise.resolve({
-                    en: {
-                        locale: 'en',
-                        locales: {
-                            'hello': 'en',
-                            'level1.level2': 'en'
-                        },
-                        translations: {
-                            hello: 'Hello {name}',
-                            'level1.level2': 'we are in the second level'
-                        }
-                    }
-                });
-            }
-        };
-        const paper = new Paper(null, null, assembler);
-        paper.loadTranslations('en', true).then(() => {
-            expect(paper.renderer.getTranslator().getLanguage().locales).to.equal({ hello: 'en', 'level1.level2': 'en' });
-            done();
-        }).catch(e => {
-            console.log(e);
-        });
-    })
 });


### PR DESCRIPTION
- Reverted messageformat library to 0.2.2, that was before GraalVM work.
- Removed logic for translation precompilation and corresponding tests
