### PR TITLE
Revert some unused code

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,23 +271,6 @@ class Paper {
             return result;
         });
     }
-
-    /**
-     * 
-     * @param {Object} templates 
-     */
-    preprocess(templates) {
-        return this.preProcessor(templates);
-    }
-
-    /**
-     * Registers templates for the handlebars
-     * 
-     * @param {Object} templats 
-     */
-    addTemplates(templates) {
-        this.renderer.addTemplates(templates);
-    }
 }
 
 module.exports = Paper;

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -67,32 +67,6 @@ Translator.create = function (acceptLanguage, allTranslations, logger = console)
     return new Translator(acceptLanguage, allTranslations, logger);
 };
 
-
-/**
- * Precompile translation functions
- * @param {Object} language
- * @param {String} key
- * @returns {Object}
- */
-Translator.compileFormatterFunction = function (language, key) {
-    const locale = language.locales[key];
-    const formatter = new MessageFormat(locale);
-
-    try {
-        const value = typeof language.translations[key] === "string"
-            ? language.translations[key]
-            : language.translations[key].toString();
-        return formatter.compile(value).toString();
-    } catch (err) {
-        console.error(`Error occured during Formatter function precompilation: ${err.message} for key "${key}"`);
-
-        const value = language.translations[key] ? language.translations[key] : key;
-        const fn = new Function(`return "${value}"`);
-        return fn.toString();
-    }
-}
-
-
 /**
  * Get translated string
  * @param {string} key

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -140,9 +140,12 @@ Translator.prototype._compileTemplate = function (key) {
     try {
         return formatter.compile(language.translations[key]);
     } catch (err) {
-        this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
+        if (err.name === 'SyntaxError') {
+            this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
 
-        return () => ''
+            return () => '';
+        }
+        throw err;
     }
 };
 

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -29,13 +29,18 @@ function Translator(acceptLanguage, allTranslations, logger = console) {
 
     const locales = LocaleParser.getLocales(acceptLanguage);
     const languages = Transformer.transform(allTranslations, locales, DEFAULT_LOCALE, this.logger);
+
     /**
      * @private
      * @type {string}
      */
     this._locale = LocaleParser.getPreferredLocale(locales, languages, DEFAULT_LOCALE);
 
-    this.setLanguage(languages);
+    /**
+     * @private
+     * @type {Object.<string, string>}
+     */
+    this._language = languages[this._locale] || {};
 
     /**
      * @private
@@ -135,14 +140,6 @@ Translator.prototype.getLanguage = function (keyFilter) {
 };
 
 /**
- * Set language object
- * @param {Object} [languages] object
- */
-Translator.prototype.setLanguage = function (languages) {
-    this._language = languages[this._locale] || {};
-};
-
-/**
  * Get formatter
  * @private
  * @param {string} locale
@@ -152,7 +149,6 @@ Translator.prototype._getFormatter = function (locale) {
     if (!this._formatters[locale]) {
         this._formatters[locale] = new MessageFormat(locale);
     }
-   
 
     return this._formatters[locale];
 };

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -155,8 +155,7 @@ describe('Translator', () => {
             },
         });
 
-        const result = translator.translate('gender_error', { gender: 'shemale' });
-        expect(result).to.equal("");
+        expect(() => translator.translate('gender_error', { gender: 'asdf' })).to.throw(Error);
 
         done();
     });


### PR DESCRIPTION
Revert some changes over the past year that are unused or related to other reversions.

* Revert addition of `preprocess` and `addTemplates` which are unused
* Revert refactor that exposed `setLanguage` function which is unused outside of `Translator` class
* Remove unused `Translator.compileFormatterFunction`
* Revert changes to translation compilation error handling leftover from failed MessageFormat upgrade

