### PR TITLE
Performance improvements for translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Pending
+* Revert some unused code that should have been removed as part of previous reversions [#260](https://github.com/bigcommerce/paper/pull/260)
+* Cleanup filterByKey [#261](https://github.com/bigcommerce/paper/pull/261)
+* Improve performance of Translator constructor through internal refactor of Transformer [#262](https://github.com/bigcommerce/paper/pull/262)
+
 ## 3.0.0-rc.53 (2021-12-20)
 - STRF-9553 Fallback languages in the chain [#258](https://github.com/bigcommerce/paper/pull/258)
 

--- a/lib/translator/filter.js
+++ b/lib/translator/filter.js
@@ -2,7 +2,10 @@
 
 /**
  * @module paper/lib/translator/filter
- */
+ *
+ * This should be considered an internal concern of Translator, and not a
+ * public interface.
+*/
 
 /*
 * Internal method to filter an object containing string keys using the given keyPrefix

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -39,7 +39,7 @@ function Translator(acceptLanguage, allTranslations, logger = console) {
 
     /**
      * @private
-     * @type {Object.<string, string>}
+     * @type {Object.<string, string|Object>}
      *
      * Looks like this:
      * {

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -18,27 +18,47 @@ const DEFAULT_LOCALE = 'en';
 
 /**
  * Translator constructor
+ *
  * @constructor
- * @param {string} acceptLanguage
- * @param {Object} allTranslations
+ * @param {string} acceptLanguage The Accept-Language header to be parsed to determine language to use
+ * @param {Object} allTranslations Object containing all translations coming from theme
  * @param {Object} logger
  */
 function Translator(acceptLanguage, allTranslations, logger = console) {
-    this.logger = logger;
-
-    const languages = Transformer.transform(allTranslations, DEFAULT_LOCALE, this.logger);
+    /**
+     * @private
+     * @type {Object}
+     */
+    this._logger = logger;
 
     /**
      * @private
      * @type {string}
      */
-    this._locale = LocaleParser.getPreferredLocale(acceptLanguage, languages, DEFAULT_LOCALE);
+    this._locale = LocaleParser.getPreferredLocale(acceptLanguage, Object.keys(allTranslations), DEFAULT_LOCALE);
 
     /**
      * @private
      * @type {Object.<string, string>}
+     *
+     * Looks like this:
+     * {
+     *   locale: 'en',
+     *   locales: {
+     *     'salutations.welcome': 'en',
+     *     'salutations.hello': 'en',
+     *     'salutations.bye': 'en',
+     *     items: 'en',
+     *   }
+     *   translations: {
+     *     'salutations.welcome': 'Welcome',
+     *     'salutations.hello': 'Hello {name}',
+     *     'salutations.bye': 'Bye bye',
+     *     items: '{count, plural, one{1 Item} other{# Items}}',
+     *   }
+     * }
      */
-    this._language = languages[this._locale] || {};
+    this._language = Transformer.transform(allTranslations, this._locale, DEFAULT_LOCALE, logger) || {};
 
     /**
      * @private
@@ -55,6 +75,7 @@ function Translator(acceptLanguage, allTranslations, logger = console) {
 
 /**
  * Translator factory method
+ *
  * @static
  * @param {string} acceptLanguage
  * @param {Object} allTranslations
@@ -67,6 +88,7 @@ Translator.create = function (acceptLanguage, allTranslations, logger = console)
 
 /**
  * Get translated string
+ *
  * @param {string} key
  * @param {Object} parameters
  * @returns {string}
@@ -84,14 +106,14 @@ Translator.prototype.translate = function (key, parameters) {
     try {
         return this._formatFunctions[key](parameters);
     } catch (err) {
-        this.logger.error(err);
-
+        this._logger.error(err);
         return '';
     }
 };
 
 /**
  * Get locale name
+ *
  * @returns {string} Translation locale
  */
 Translator.prototype.getLocale = function () {
@@ -100,6 +122,7 @@ Translator.prototype.getLocale = function () {
 
 /**
  * Get language object
+ *
  * @param {string} [keyFilter]
  * @returns {Object} Language object
  */
@@ -113,6 +136,7 @@ Translator.prototype.getLanguage = function (keyFilter) {
 
 /**
  * Get formatter
+ *
  * @private
  * @param {string} locale
  * @returns {MessageFormat} Return cached or new MessageFormat
@@ -127,6 +151,8 @@ Translator.prototype._getFormatter = function (locale) {
 
 /**
  * Compile a translation template and return a formatter function
+ *
+ * @private
  * @param {string} key
  * @return {Function}
  */
@@ -139,8 +165,7 @@ Translator.prototype._compileTemplate = function (key) {
         return formatter.compile(language.translations[key]);
     } catch (err) {
         if (err.name === 'SyntaxError') {
-            this.logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
-
+            this._logger.error(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
             return () => '';
         }
 

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -26,14 +26,13 @@ const DEFAULT_LOCALE = 'en';
 function Translator(acceptLanguage, allTranslations, logger = console) {
     this.logger = logger;
 
-    const locales = LocaleParser.getLocales(acceptLanguage);
-    const languages = Transformer.transform(allTranslations, locales, DEFAULT_LOCALE, this.logger);
+    const languages = Transformer.transform(allTranslations, DEFAULT_LOCALE, this.logger);
 
     /**
      * @private
      * @type {string}
      */
-    this._locale = LocaleParser.getPreferredLocale(locales, languages, DEFAULT_LOCALE);
+    this._locale = LocaleParser.getPreferredLocale(acceptLanguage, languages, DEFAULT_LOCALE);
 
     /**
      * @private

--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -14,7 +14,7 @@ const Transformer = require('./transformer');
  * @private
  * @type {string}
  */
-const DEFAULT_LOCALE = 'en';
+const FALLBACK_LOCALE = 'en';
 
 /**
  * Translator constructor
@@ -33,9 +33,9 @@ function Translator(acceptLanguage, allTranslations, logger = console) {
 
     /**
      * @private
-     * @type {string}
+     * @type {string[]}
      */
-    this._locale = LocaleParser.getPreferredLocale(acceptLanguage, Object.keys(allTranslations), DEFAULT_LOCALE);
+    this._preferredLocales = LocaleParser.getPreferredLocales(acceptLanguage, Object.keys(allTranslations), FALLBACK_LOCALE);
 
     /**
      * @private
@@ -58,7 +58,7 @@ function Translator(acceptLanguage, allTranslations, logger = console) {
      *   }
      * }
      */
-    this._language = Transformer.transform(allTranslations, this._locale, DEFAULT_LOCALE, logger) || {};
+    this._language = Transformer.transform(allTranslations, this._preferredLocales, this._logger) || {};
 
     /**
      * @private
@@ -112,12 +112,12 @@ Translator.prototype.translate = function (key, parameters) {
 };
 
 /**
- * Get locale name
+ * Get primary locale name
  *
- * @returns {string} Translation locale
+ * @returns {string} Primary locale
  */
 Translator.prototype.getLocale = function () {
-    return this._locale;
+    return this._preferredLocales[0];
 };
 
 /**

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -2,55 +2,72 @@
 
 /**
  * @module paper/lib/translator/locale-parser
+ *
+ * This should be considered an internal concern of Translator, and not a
+ * public interface.
  */
 const AcceptLanguageParser = require('accept-language-parser');
 const MessageFormat = require('messageformat');
 
 /**
- * Parse the Accept-Language header and return the preferred locale after matching
- * up against the list of supported locales.
+ * Parse the Accept-Language header and return the list of preferred locales
+ * filtered based on the list of supported locales and making sure that MessageFormat
+ * supports it as well.
  *
- * @param {string} acceptLanguage The Accept-Language header
- * @param {Array} supportedLocales A list of supported locales
- * @param {string} defaultLocale The default fallback locale
- * @returns {string}
+ * @param {string} acceptLanguageHeader The Accept-Language header
+ * @param {Array} availableLocales A list of available locales from translations file
+ * @param {string} fallbackLocale The default fallback locale
+ * @returns {string[]} List of preferred+supported locales
  */
-function getPreferredLocale(acceptLanguage, supportedLocales, defaultLocale) {
-    const acceptableLocales = getLocales(acceptLanguage);
-    const preferredLocale = acceptableLocales.find(locale => supportedLocales.includes(locale)) || defaultLocale;
+function getPreferredLocales(acceptLanguageHeader, availableLocales, fallbackLocale) {
+    // Parse header
+    const acceptableLocales = parseLocales(acceptLanguageHeader, fallbackLocale);
 
-    // Make sure that MessageFormat supports it
-    try {
-        new MessageFormat(preferredLocale);
-        return preferredLocale;
-    } catch (err) {
-        return defaultLocale;
-    }
+    // Filter based on list of available locales
+    const preferredLocales = acceptableLocales.filter(locale => availableLocales.includes(locale));
+
+    // Filter list based on what MessageFormat actually supports
+    return preferredLocales.filter(locale => {
+        try {
+            new MessageFormat(locale);
+            return true;
+        } catch (err) {
+            return false;
+        }
+    });
 }
 
 /**
  * Parse Accept-Language header and return a list of locales
  *
- * @param {string} acceptLanguage The Accept-Language header
- * @returns {string[]} List of locale identifiers
+ * @param {string} acceptLanguageHeader The Accept-Language header
+ * @param {string} fallbackLocale The default fallback locale
+ * @returns {string[]} Ordered list of locale identifiers
  */
-function getLocales(acceptLanguage) {
-    const localeObjects = AcceptLanguageParser.parse(acceptLanguage);
+function parseLocales(acceptLanguageHeader, fallbackLocale) {
+    // Parse the header, adding fallback to the very end of the list (via low quality)
+    const parsed = AcceptLanguageParser.parse(`${acceptLanguageHeader},${fallbackLocale};q=0`);
 
-    const locales = localeObjects.map(localeObject => {
-        return localeObject.region ? `${localeObject.code}-${localeObject.region}` : localeObject.code;
-    });
+    // Iterate through the parsed locales, pushing into a Set to deduplicate as we go along
+    const locales = new Set();
+    for (let i = 0; i < parsed.length; i++) {
+        const locale = parsed[i];
+        if (locale.region && locale.code) {
+            locales.add(`${locale.code}-${locale.region}`);
+        }
 
-    //  Safari sends only one language code, this is to have a default fallback in case we don't have that language
-    //  As an example we may not have fr-FR so add fr to the header
-    if (locales.length === 1 && locales[0].split('-').length === 2) {
-        locales.push(locales[0].split('-')[0]);
+        // Insert regionless fallbacks into the chain. As an example, if fr-FR is in the chain,
+        // but fr is not, add it. This enables appropriate fallback logic for the translations file.
+        // If we have already seen it previously, it will not be added to the Set.
+        if (locale.code) {
+            locales.add(locale.code);
+        }
     }
 
-    return locales;
+    // Return an array based on insertion order of the Set
+    return [...locales];
  }
 
 module.exports = {
-    getPreferredLocale: getPreferredLocale,
-    getLocales: getLocales,
+    getPreferredLocales,
 };

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -7,28 +7,32 @@ const AcceptLanguageParser = require('accept-language-parser');
 const MessageFormat = require('messageformat');
 
 /**
- * Get preferred locale
- * @param {string} acceptLanguage
- * @param {Object} languages
- * @param {string} defaultLocale
+ * Parse the Accept-Language header and return the preferred locale after matching
+ * up against the list of supported locales.
+ *
+ * @param {string} acceptLanguage The Accept-Language header
+ * @param {Array} supportedLocales A list of supported locales
+ * @param {string} defaultLocale The default fallback locale
  * @returns {string}
  */
-function getPreferredLocale(acceptLanguage, languages, defaultLocale) {
-    const locale = getLocales(acceptLanguage).find(locale => languages[locale]) || defaultLocale;
+function getPreferredLocale(acceptLanguage, supportedLocales, defaultLocale) {
+    const acceptableLocales = getLocales(acceptLanguage);
+    const preferredLocale = acceptableLocales.find(locale => supportedLocales.includes(locale)) || defaultLocale;
 
+    // Make sure that MessageFormat supports it
     try {
-        new MessageFormat(locale);
-
-        return locale;
+        new MessageFormat(preferredLocale);
+        return preferredLocale;
     } catch (err) {
         return defaultLocale;
     }
 }
 
 /**
- * Parse locale header
- * @param {string} acceptLanguage
- * @returns {string[]} Locales
+ * Parse Accept-Language header and return a list of locales
+ *
+ * @param {string} acceptLanguage The Accept-Language header
+ * @returns {string[]} List of locale identifiers
  */
 function getLocales(acceptLanguage) {
     const localeObjects = AcceptLanguageParser.parse(acceptLanguage);

--- a/lib/translator/locale-parser.js
+++ b/lib/translator/locale-parser.js
@@ -8,13 +8,14 @@ const MessageFormat = require('messageformat');
 
 /**
  * Get preferred locale
- * @param {string[]} locales
+ * @param {string} acceptLanguage
  * @param {Object} languages
  * @param {string} defaultLocale
  * @returns {string}
  */
-function getPreferredLocale(locales, languages, defaultLocale) {
-    const locale = locales.find(locale => languages[locale]) || defaultLocale;
+function getPreferredLocale(acceptLanguage, languages, defaultLocale) {
+    const locale = getLocales(acceptLanguage).find(locale => languages[locale]) || defaultLocale;
+
     try {
         new MessageFormat(locale);
 

--- a/lib/translator/transformer.js
+++ b/lib/translator/transformer.js
@@ -5,119 +5,282 @@
  */
 
 /**
- * Transform translations
- * @param {Object} allTranslations
+ * Transform translations from the representation provided by stencil bundle
+ * into something that enables fast lookups in the `lang` helper.
+ *
+ * The `allTranslations` object looks like this:
+ * {
+ *   en: {
+ *     salutations: {
+ *       welcome: 'Welcome',
+ *       hello: 'Hello {name}',
+ *       bye: 'Bye bye',
+ *     }
+ *     items: '{count, plural, one{1 Item} other{# Items}}',
+ *   },
+ *   fr: {
+ *     salutations: {
+ *       hello: 'Bonjour {name}',
+ *       bye: 'au revoir',
+ *     }
+ *   },
+ *   'fr-CA': {
+ *     salutations: {
+ *       hello: 'Salut {name}',
+ *     },
+ *   },
+ * }
+ *
+ * The return value looks like this, assuming preferredLocale of 'fr-CA' and defaultLocale of 'en':
+ * {
+ *   'fr-CA': {
+ *     locale: 'fr-CA',
+ *     locales: {
+ *       'salutations.welcome': 'en',
+ *       'salutations.hello': 'fr-CA',
+ *       'salutations.bye': 'fr',
+ *       items: 'en',
+ *     },
+ *     translations: {
+ *       'salutations.welcome': 'Welcome',
+ *       'salutations.hello': 'Salut {name}',
+ *       'salutations.bye': 'au revoir',
+ *       items: '{count, plural, one{1 Item} other{# Items}}',
+ *     }
+ *   },
+ * }
+ *
+ * @param {Object.<string, Object>} allTranslations
+ * @param {string} preferredLocale
  * @param {string} defaultLocale
  * @param {Object} logger
  * @returns {Object.<string, Object>} Transformed translations
  */
-function transform(allTranslations, defaultLocale, logger = console) {
-    return cascade(flatten(allTranslations, logger), defaultLocale);
+function transform(allTranslations, preferredLocale, defaultLocale, logger = console) {
+    const flattened = flatten(allTranslations, preferredLocale, defaultLocale, logger);
+    return cascade(flattened, preferredLocale, defaultLocale);
 }
 
 /**
- * Flatten translations
- * @param {Object} allTranslations
+ * Flatten translation keys to a single top-level namespace, keeping only necessary
+ * languages based on preferredLocale and defaultLocale.
+ *
+ * The `allTranslations` object looks like this:
+ * {
+ *   en: {
+ *     salutations: {
+ *       welcome: 'Welcome',
+ *       hello: 'Hello {name}',
+ *       bye: 'Bye bye',
+ *       formal: {
+ *           bye: 'Farewell',
+ *       }
+ *     }
+ *     items: '{count, plural, one{1 Item} other{# Items}}',
+ *   },
+ *   fr: {
+ *     salutations: {
+ *       hello: 'Bonjour {name}',
+ *       bye: 'au revoir',
+ *     }
+ *   },
+ *   'fr-CA': {
+ *     salutations: {
+ *       hello: 'Salut {name}',
+ *     },
+ *   },
+ *   'de': {
+ *     salutations: {
+ *       hello: 'Hallo {name}',
+ *     },
+ *   },
+ * }
+ *
+ * The return value looks like this, assuming preferredLocale of 'fr-CA' and defaultLocale of 'en':
+ * {
+ *   en: {
+ *     'salutations.welcome': 'Welcome',
+ *     'salutations.hello': 'Hello {name}',
+ *     'salutations.bye': 'Bye bye',
+ *     'salutations.formal.bye': 'Farewell',
+ *     items: '{count, plural, one{1 Item} other{# Items}}',
+ *   },
+ *   fr: {
+ *     'salutations.hello': 'Bonjour {name}',
+ *     'salutations.bye': 'au revoir',
+ *   },
+ *   'fr-CA': {
+ *     'salutations.hello': 'Salut {name}',
+ *   },
+ * }
+ * @param {Object.<string, Object>} translations
+ * @param {string} preferredLocale
+ * @param {string} defaultLocale
  * @param {Object} logger
- * @returns {Object.<string, Object>} Flatten translations
+ * @returns {Object.<string, Object>} Flattened translations
  */
-function flatten(allTranslations, logger = console) {
-    return Object.entries(allTranslations)
-        .reduce(
-            (result, [locale, translation]) => {
-                try {
-                    result[locale] = flattenObject(translation);
-                } catch (err) {
-                    logger.error(`Failed to parse ${locale} - Error: ${err}`);
-
-                    result[locale] = {};
-                }
-
-                return result;
-            },
-            {}
-        );
+function flatten(translations, preferredLocale, defaultLocale, logger = console) {
+    const result = {};
+    const localeList = preferredLocaleList(translations, preferredLocale, defaultLocale);
+    for (let i = 0; i < localeList.length; i++) {
+        const locale = localeList[i];
+        try {
+            result[locale] = flattenObject(translations[locale]);
+        } catch (err) {
+            logger.error(`Failed to flatten ${locale} - Error: ${err}`);
+            result[locale] = {};
+        }
+    }
+    return result;
 }
 
 /**
- * Cascade translations
- * @param {Object} allTranslations Flattened translations
+ * Cascade translations by providing appropriate fallback values. For example, if 'fr-CA'
+ * is requested but the translation override doesn't exist, we fallback first to 'fr', then
+ * to the defaultLocale (usually 'en').
+ *
+ * flattenedTranslations looks like this:
+ * {
+ *   en: {
+ *     'salutations.welcome': 'Welcome',
+ *     'salutations.hello': 'Hello {name}',
+ *     'salutations.bye': 'Bye bye',
+ *     items: '{count, plural, one{1 Item} other{# Items}}',
+ *   },
+ *   fr: {
+ *     'salutations.hello': 'Bonjour {name}',
+ *     'salutations.bye': 'au revoir',
+ *   },
+ *   'fr-CA': {
+ *     'salutations.hello': 'Salut {name}',
+ *   },
+ * }
+ *
+ * The return value looks like this, assuming preferredLocale of 'fr-CA' and defaultLocale of 'en':
+ * {
+ *   'fr-CA': {
+ *     locale: 'fr-CA',
+ *     locales: {
+ *       'salutations.welcome': 'en',
+ *       'salutations.hello': 'fr-CA',
+ *       'salutations.bye': 'fr',
+ *       items: 'en',
+ *     },
+ *     translations: {
+ *       'salutations.welcome': 'Welcome',
+ *       'salutations.hello': 'Salut {name}',
+ *       'salutations.bye': 'au revoir',
+ *       items: '{count, plural, one{1 Item} other{# Items}}',
+ *     }
+ *   },
+ * }
+ *
+ * @param {Object.<string, Object>} translations Flattened translations
+ * @param {string} preferredLocale
  * @param {string} defaultLocale
- * @returns {Object.<string, Object>} Language objects
+ * @returns {Object.<string, Object>} Cascaded translations spec
  */
-function cascade(allTranslations, defaultLocale) {
-    return Object.entries(allTranslations)
-        .reduce(
-            (result, [locale, translations]) => {
-                if (!result[locale]) {
-                    result[locale] = { locale: locale, locales: {}, translations: {} };
-                }
+function cascade(translations, preferredLocale, defaultLocale) {
+    const result = { locale: preferredLocale, locales: {}, translations: {} };
 
-                const regionCodes = locale.split('-');
-                for (let regionIndex = regionCodes.length - 1; regionIndex >= 0; regionIndex--) {
-                    const parentLocale = getParentLocale(regionCodes, regionIndex, defaultLocale);
-                    const parentTranslations = allTranslations[parentLocale] || {};
+    // Process the list of locales in reverse order of preference for proper layering
+    const localeList = preferredLocaleList(translations, preferredLocale, defaultLocale).reverse();
 
-                    new Set(
-                        Object.keys(parentTranslations).concat(Object.keys(translations))
-                    ).forEach((key) => {
-                        if (translations[key]) {
-                            result[locale].locales[key] = locale;
-                            result[locale].translations[key] = translations[key];
-                        } else if (!result[locale].translations[key]) {
-                            result[locale].locales[key] = parentLocale;
-                            result[locale].translations[key] = parentTranslations[key];
-                        }
-                    });
-                }
-
-                return result;
-            },
-            {}
-        );
-}
-
-/**
- * Get parent locale
- * @private
- * @param {string[]} regionCodes
- * @param {number} regionIndex
- * @param {string} defaultLocale
- * @returns {string} Parent locale
- */
-function getParentLocale(regionCodes, regionIndex, defaultLocale) {
-    if (regionIndex === 0 && regionCodes[0] !== defaultLocale) {
-        return defaultLocale;
+    // Build the layered set of translations
+    for (let i = 0; i < localeList.length; i++) {
+        const locale = localeList[i];
+        for (const key in translations[locale]) {
+            result.locales[key] = locale;
+            result.translations[key] = translations[locale][key];
+        }
     }
 
-    return regionCodes.slice(0, regionIndex).join('-');
+    return result;
 }
 
 /**
- * Brings nested JSON parameters to the top level while preserving namespaces with . as a delimiter
+ * Internal method to flatten nested JSON to the top level, transforming nested keys
+ * using dot syntax.
+ *
+ * If the object looks like this:
+ * {
+ *   salutations: {
+ *     welcome: 'Welcome',
+ *     hello: 'Hello {name}',
+ *     bye: 'Bye bye',
+ *     formal: {
+ *         bye: 'Farewell',
+ *     }
+ *   }
+ * }
+ *
+ * Then the return value would look like this:
+ * {
+ *   'salutations.welcome': 'Welcome',
+ *   'salutations.hello': 'Hello {name}',
+ *   'salutations.bye': 'Bye bye',
+ *   'salutations.formal.bye': 'Farewell',
+ * },
+ *
  * @private
- * @param {Object} object
- * @param {Object} [result={}]
- * @param {string} [parentKey='']
- * @returns {Object} Flatten object
+ * @param {Object} object The object to process
+ * @param {Object} [result] Caller is expected to pass in an empty object to store the result
+ * @param {string} [parentKey] An optional parent key, used in recursive calls
+ * @returns {Object} Object with flattened keys
  */
-function flattenObject(object, result = {}, parentKey = '') {
-    return Object.entries(object)
-        .reduce(
-            (currentLayer, [key, innerValue]) => {
-                const resultKey = parentKey !== '' ? `${parentKey}.${key}` : key;
-                if (typeof innerValue === 'object') {
-                    return flattenObject(innerValue, currentLayer, resultKey);
-                }
-                currentLayer[resultKey] = innerValue;
-                return currentLayer;
-            },
-            result
-        );
+function flattenObject(object, result, parentKey) {
+    result = result || {};
+    parentKey = parentKey || '';
+
+    const keys = Object.keys(object);
+    for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        const flattenedKey = parentKey !== '' ? `${parentKey}.${key}` : key;
+        if (typeof object[key] === 'object') {
+            flattenObject(object[key], result, flattenedKey);
+        } else {
+            result[flattenedKey] = object[key];
+        }
+    }
+    return result;
+}
+
+/**
+ * Internal method to return the list of possible locales to use from the incoming
+ * translations object based on availability and preference.
+ *
+ * @private
+ * @param {Object.<String, Object>} translations Flattened translations
+ * @param {String} preferredLocale
+ * @param {String} defaultLocale
+ * @returns {Array<String>} Expanded list of locales in order of preference
+ */
+function preferredLocaleList(translations, preferredLocale, defaultLocale) {
+    const result = [];
+
+    // Start with preferred locale if available
+    if (typeof translations[preferredLocale] !== 'undefined') {
+        result.push(preferredLocale);
+    }
+
+    // If preferred locale includes language and region, fallback to regionless language if available
+    if (preferredLocale.includes('-')) {
+        const regionless = preferredLocale.split('-')[0];
+        if (typeof translations[regionless] !== 'undefined') {
+            result.push(regionless);
+        }
+    }
+
+    // Fallback to default locale if available
+    if (typeof translations[defaultLocale] !== 'undefined' && preferredLocale !== defaultLocale) {
+        result.push(defaultLocale);
+    }
+
+    return result;
 }
 
 module.exports = {
-    cascade: cascade,
-    flatten: flatten,
-    transform: transform,
+    cascade,
+    flatten,
+    transform,
 };

--- a/lib/translator/transformer.js
+++ b/lib/translator/transformer.js
@@ -2,6 +2,9 @@
 
 /**
  * @module paper/lib/translator/transformer
+ *
+ * This should be considered an internal concern of Translator, and not a
+ * public interface.
  */
 
 /**
@@ -31,7 +34,7 @@
  *   },
  * }
  *
- * The return value looks like this, assuming preferredLocale of 'fr-CA' and defaultLocale of 'en':
+ * The return value looks like this, assuming preferredLocales of ['fr-CA', 'en']:
  * {
  *   'fr-CA': {
  *     locale: 'fr-CA',
@@ -51,19 +54,18 @@
  * }
  *
  * @param {Object.<string, Object>} allTranslations
- * @param {string} preferredLocale
- * @param {string} defaultLocale
+ * @param {string[]} preferredLocales
  * @param {Object} logger
  * @returns {Object.<string, Object>} Transformed translations
  */
-function transform(allTranslations, preferredLocale, defaultLocale, logger = console) {
-    const flattened = flatten(allTranslations, preferredLocale, defaultLocale, logger);
-    return cascade(flattened, preferredLocale, defaultLocale);
+function transform(allTranslations, preferredLocales, logger = console) {
+    const flattened = flatten(allTranslations, preferredLocales, logger);
+    return cascade(flattened, preferredLocales);
 }
 
 /**
  * Flatten translation keys to a single top-level namespace, keeping only necessary
- * languages based on preferredLocale and defaultLocale.
+ * languages based on preferredLocales.
  *
  * The `allTranslations` object looks like this:
  * {
@@ -96,7 +98,7 @@ function transform(allTranslations, preferredLocale, defaultLocale, logger = con
  *   },
  * }
  *
- * The return value looks like this, assuming preferredLocale of 'fr-CA' and defaultLocale of 'en':
+ * The return value looks like this, assuming preferredLocales of ['fr-CA', 'en']:
  * {
  *   en: {
  *     'salutations.welcome': 'Welcome',
@@ -114,16 +116,14 @@ function transform(allTranslations, preferredLocale, defaultLocale, logger = con
  *   },
  * }
  * @param {Object.<string, Object>} translations
- * @param {string} preferredLocale
- * @param {string} defaultLocale
+ * @param {string[]} preferredLocales
  * @param {Object} logger
  * @returns {Object.<string, Object>} Flattened translations
  */
-function flatten(translations, preferredLocale, defaultLocale, logger = console) {
+function flatten(translations, preferredLocales, logger = console) {
     const result = {};
-    const localeList = preferredLocaleList(translations, preferredLocale, defaultLocale);
-    for (let i = 0; i < localeList.length; i++) {
-        const locale = localeList[i];
+    for (let i = 0; i < preferredLocales.length; i++) {
+        const locale = preferredLocales[i];
         try {
             result[locale] = flattenObject(translations[locale]);
         } catch (err) {
@@ -156,7 +156,7 @@ function flatten(translations, preferredLocale, defaultLocale, logger = console)
  *   },
  * }
  *
- * The return value looks like this, assuming preferredLocale of 'fr-CA' and defaultLocale of 'en':
+ * The return value looks like this, assuming preferredLocales of ['fr-CA', 'en']:
  * {
  *   'fr-CA': {
  *     locale: 'fr-CA',
@@ -176,15 +176,14 @@ function flatten(translations, preferredLocale, defaultLocale, logger = console)
  * }
  *
  * @param {Object.<string, Object>} translations Flattened translations
- * @param {string} preferredLocale
- * @param {string} defaultLocale
+ * @param {string[]} preferredLocales Ordered list of preferred locales
  * @returns {Object.<string, Object>} Cascaded translations spec
  */
-function cascade(translations, preferredLocale, defaultLocale) {
-    const result = { locale: preferredLocale, locales: {}, translations: {} };
+function cascade(translations, preferredLocales) {
+    const result = { locale: preferredLocales[0], locales: {}, translations: {} };
 
     // Process the list of locales in reverse order of preference for proper layering
-    const localeList = preferredLocaleList(translations, preferredLocale, defaultLocale).reverse();
+    const localeList = preferredLocales.slice().reverse();
 
     // Build the layered set of translations
     for (let i = 0; i < localeList.length; i++) {
@@ -242,40 +241,6 @@ function flattenObject(object, result, parentKey) {
             result[flattenedKey] = object[key];
         }
     }
-    return result;
-}
-
-/**
- * Internal method to return the list of possible locales to use from the incoming
- * translations object based on availability and preference.
- *
- * @private
- * @param {Object.<String, Object>} translations Flattened translations
- * @param {String} preferredLocale
- * @param {String} defaultLocale
- * @returns {Array<String>} Expanded list of locales in order of preference
- */
-function preferredLocaleList(translations, preferredLocale, defaultLocale) {
-    const result = [];
-
-    // Start with preferred locale if available
-    if (typeof translations[preferredLocale] !== 'undefined') {
-        result.push(preferredLocale);
-    }
-
-    // If preferred locale includes language and region, fallback to regionless language if available
-    if (preferredLocale.includes('-')) {
-        const regionless = preferredLocale.split('-')[0];
-        if (typeof translations[regionless] !== 'undefined') {
-            result.push(regionless);
-        }
-    }
-
-    // Fallback to default locale if available
-    if (typeof translations[defaultLocale] !== 'undefined' && preferredLocale !== defaultLocale) {
-        result.push(defaultLocale);
-    }
-
     return result;
 }
 

--- a/lib/translator/transformer.js
+++ b/lib/translator/transformer.js
@@ -7,13 +7,12 @@
 /**
  * Transform translations
  * @param {Object} allTranslations
- * @param {string[]} locales
  * @param {string} defaultLocale
  * @param {Object} logger
  * @returns {Object.<string, Object>} Transformed translations
  */
-function transform(allTranslations, locales, defaultLocale, logger = console) {
-    return cascade(flatten(allTranslations, logger), locales, defaultLocale);
+function transform(allTranslations, defaultLocale, logger = console) {
+    return cascade(flatten(allTranslations, logger), defaultLocale);
 }
 
 /**
@@ -42,14 +41,11 @@ function flatten(allTranslations, logger = console) {
 
 /**
  * Cascade translations
- * 
  * @param {Object} allTranslations Flattened translations
- * @param {string[]} locales
  * @param {string} defaultLocale
  * @returns {Object.<string, Object>} Language objects
  */
-function cascade(allTranslations, locales, defaultLocale) {
-    const availableLocales = addDefaultLocale(locales, defaultLocale);
+function cascade(allTranslations, defaultLocale) {
     return Object.entries(allTranslations)
         .reduce(
             (result, [locale, translations]) => {
@@ -59,7 +55,6 @@ function cascade(allTranslations, locales, defaultLocale) {
 
                 const regionCodes = locale.split('-');
                 for (let regionIndex = regionCodes.length - 1; regionIndex >= 0; regionIndex--) {
-                    // keeping parent locale logic as a source of truth to track "available" keys 
                     const parentLocale = getParentLocale(regionCodes, regionIndex, defaultLocale);
                     const parentTranslations = allTranslations[parentLocale] || {};
 
@@ -70,11 +65,8 @@ function cascade(allTranslations, locales, defaultLocale) {
                             result[locale].locales[key] = locale;
                             result[locale].translations[key] = translations[key];
                         } else if (!result[locale].translations[key]) {
-                            const preparedLocales = prepareLocales(availableLocales, locale);
-                            const { nextAvailableLocale, nextAvailableTranslation } = getNextLocaleTranslation(preparedLocales, allTranslations, key);
-                             // fallback to old logic in case no languages are present in lang header
-                            result[locale].locales[key] = nextAvailableLocale || parentLocale;
-                            result[locale].translations[key] = nextAvailableTranslation || parentTranslations[key]; 
+                            result[locale].locales[key] = parentLocale;
+                            result[locale].translations[key] = parentTranslations[key];
                         }
                     });
                 }
@@ -83,56 +75,6 @@ function cascade(allTranslations, locales, defaultLocale) {
             },
             {}
         );
-}
-
-/**
- * Adding default locale in case it's absent
- * 
- * @param {string[]} locales
- * @param {string} defaultLocale
- * @returns {string[]}
- */
- function addDefaultLocale(locales, defaultLocale) {
-    // the object will be mutated, so making a copy of it.
-   const copiedLocales = [...locales];
-   if (locales[locales.length - 1] !== defaultLocale) {
-       copiedLocales.push(defaultLocale);
-   }
-   return copiedLocales;
-}
-
-/**
- * Adding default locale in case it's absent
- * 
- * @param {string[]} availableLocales
- * @param {string} currentLocale
- * @returns {string[]}
- */
-function prepareLocales(availableLocales, currentLocale) {
-    const localeIndex = availableLocales.findIndex(locale => locale == currentLocale);
-    const locales = availableLocales.slice(localeIndex + 1);
-    return locales;
-}
-
-/**
- * Returns next available pair (locale and translation) in the chain
- * 
- * @param {string[]} locales
- * @param {Object} allTranslations Flattened translations
- * @param {string} key
- * @returns {Object.<string, string>} selected locale and translation
- */
-function getNextLocaleTranslation(locales, allTranslations, key) {
-    for (const locale of locales) {
-        if (allTranslations[locale] && allTranslations[locale][key]) {
-            return {
-                nextAvailableLocale: locale,
-                nextAvailableTranslation: allTranslations[locale][key],
-            }
-        }
-    }
-
-    return {};
 }
 
 /**

--- a/lib/translator/transformer.js
+++ b/lib/translator/transformer.js
@@ -36,27 +36,25 @@
  *
  * The return value looks like this, assuming preferredLocales of ['fr-CA', 'en']:
  * {
- *   'fr-CA': {
- *     locale: 'fr-CA',
- *     locales: {
- *       'salutations.welcome': 'en',
- *       'salutations.hello': 'fr-CA',
- *       'salutations.bye': 'fr',
- *       items: 'en',
- *     },
- *     translations: {
- *       'salutations.welcome': 'Welcome',
- *       'salutations.hello': 'Salut {name}',
- *       'salutations.bye': 'au revoir',
- *       items: '{count, plural, one{1 Item} other{# Items}}',
- *     }
+ *   locale: 'fr-CA',
+ *   locales: {
+ *     'salutations.welcome': 'en',
+ *     'salutations.hello': 'fr-CA',
+ *     'salutations.bye': 'fr',
+ *     items: 'en',
  *   },
+ *   translations: {
+ *     'salutations.welcome': 'Welcome',
+ *     'salutations.hello': 'Salut {name}',
+ *     'salutations.bye': 'au revoir',
+ *     items: '{count, plural, one{1 Item} other{# Items}}',
+ *   }
  * }
  *
  * @param {Object.<string, Object>} allTranslations
  * @param {string[]} preferredLocales
  * @param {Object} logger
- * @returns {Object.<string, Object>} Transformed translations
+ * @returns {Object.<string, string|Object>} Transformed translations
  */
 function transform(allTranslations, preferredLocales, logger = console) {
     const flattened = flatten(allTranslations, preferredLocales, logger);
@@ -158,26 +156,24 @@ function flatten(translations, preferredLocales, logger = console) {
  *
  * The return value looks like this, assuming preferredLocales of ['fr-CA', 'en']:
  * {
- *   'fr-CA': {
- *     locale: 'fr-CA',
- *     locales: {
- *       'salutations.welcome': 'en',
- *       'salutations.hello': 'fr-CA',
- *       'salutations.bye': 'fr',
- *       items: 'en',
- *     },
- *     translations: {
- *       'salutations.welcome': 'Welcome',
- *       'salutations.hello': 'Salut {name}',
- *       'salutations.bye': 'au revoir',
- *       items: '{count, plural, one{1 Item} other{# Items}}',
- *     }
+ *   locale: 'fr-CA',
+ *   locales: {
+ *     'salutations.welcome': 'en',
+ *     'salutations.hello': 'fr-CA',
+ *     'salutations.bye': 'fr',
+ *     items: 'en',
  *   },
+ *   translations: {
+ *     'salutations.welcome': 'Welcome',
+ *     'salutations.hello': 'Salut {name}',
+ *     'salutations.bye': 'au revoir',
+ *     items: '{count, plural, one{1 Item} other{# Items}}',
+ *   }
  * }
  *
  * @param {Object.<string, Object>} translations Flattened translations
  * @param {string[]} preferredLocales Ordered list of preferred locales
- * @returns {Object.<string, Object>} Cascaded translations spec
+ * @returns {Object.<string, string|Object>} Cascaded translations spec
  */
 function cascade(translations, preferredLocales) {
     const result = { locale: preferredLocales[0], locales: {}, translations: {} };

--- a/spec/lib/filter.js
+++ b/spec/lib/filter.js
@@ -20,7 +20,7 @@ describe('Filter', () => {
                 throw err;
             }
 
-            const translations = Transformer.transform(JSON.parse(data), 'en', 'en');
+            const translations = Transformer.transform(JSON.parse(data), ['en']);
             filtered = Filter.filterByKey(translations, 'header');
             expected = {
                 locale: 'en',

--- a/spec/lib/filter.js
+++ b/spec/lib/filter.js
@@ -20,8 +20,8 @@ describe('Filter', () => {
                 throw err;
             }
 
-            const translations = Transformer.transform(JSON.parse(data), ['en'], 'en');
-            filtered = Filter.filterByKey(translations['en'], 'header');
+            const translations = Transformer.transform(JSON.parse(data), 'en', 'en');
+            filtered = Filter.filterByKey(translations, 'header');
             expected = {
                 locale: 'en',
                 locales: {

--- a/spec/lib/transformer.js
+++ b/spec/lib/transformer.js
@@ -1,0 +1,187 @@
+const Code = require('code');
+const Lab = require('lab');
+const Transformer = require('../../lib/translator/transformer');
+
+const lab = exports.lab = Lab.script();
+const describe = lab.experiment;
+const expect = Code.expect;
+const it = lab.it;
+
+describe('Transformer', () => {
+    const translations = {
+        en: {
+            welcome: 'Welcome',
+            hello: 'Hello {name}',
+            bye: 'Bye bye',
+            items: '{count, plural, one{1 Item} other{# Items}}',
+            level1: {
+                level2: 'we are on the second level',
+            },
+        },
+        fr: {
+            hello: 'Bonjour {name}',
+            bye: 'au revoir',
+            level1: {
+                level2: 'nous sommes dans le deuxième niveau',
+            },
+        },
+        'fr-CA': {
+            hello: 'Salut {name}',
+        },
+        yolo: {
+            welcome: 'yolo',
+        },
+        zh: {
+            days: '{count, plural, other{# 天}}',
+        },
+    };
+
+    const flattened = {
+        en: {
+            welcome: 'Welcome',
+            hello: 'Hello {name}',
+            bye: 'Bye bye',
+            items: '{count, plural, one{1 Item} other{# Items}}',
+            'level1.level2': 'we are on the second level'
+        },
+        fr: {
+            hello: 'Bonjour {name}',
+            bye: 'au revoir',
+            'level1.level2': 'nous sommes dans le deuxième niveau'
+        },
+        'fr-CA': {
+            hello: 'Salut {name}'
+        },
+        yolo: {
+            welcome: 'yolo'
+        },
+        zh: {
+            days: '{count, plural, other{# 天}}'
+        }
+    };
+
+    const cascaded = {
+        en: {
+            locale: 'en',
+            locales: {
+                welcome: 'en',
+                hello: 'en',
+                bye: 'en',
+                items: 'en',
+                'level1.level2': 'en'
+            },
+            translations: {
+                welcome: 'Welcome',
+                hello: 'Hello {name}',
+                bye: 'Bye bye',
+                items: '{count, plural, one{1 Item} other{# Items}}',
+                'level1.level2': 'we are on the second level'
+            }
+        },
+        fr: {
+            locale: 'fr',
+            locales: {
+                welcome: 'en',
+                hello: 'fr',
+                bye: 'fr',
+                items: 'en',
+                'level1.level2': 'fr'
+            },
+            translations: {
+                welcome: 'Welcome',
+                hello: 'Bonjour {name}',
+                bye: 'au revoir',
+                items: '{count, plural, one{1 Item} other{# Items}}',
+                'level1.level2': 'nous sommes dans le deuxième niveau'
+            }
+        },
+        'fr-CA': {
+            locale: 'fr-CA',
+            locales: {
+                welcome: 'en',
+                hello: 'fr-CA',
+                bye: 'fr',
+                items: 'en',
+                'level1.level2': 'fr'
+            },
+            translations: {
+                welcome: 'Welcome',
+                hello: 'Salut {name}',
+                bye: 'au revoir',
+                items: '{count, plural, one{1 Item} other{# Items}}',
+                'level1.level2': 'nous sommes dans le deuxième niveau'
+            }
+        },
+        yolo: {
+            locale: 'yolo',
+            locales: {
+                welcome: 'yolo',
+                hello: 'en',
+                bye: 'en',
+                items: 'en',
+                'level1.level2': 'en'
+            },
+            translations: {
+                welcome: 'yolo',
+                hello: 'Hello {name}',
+                bye: 'Bye bye',
+                items: '{count, plural, one{1 Item} other{# Items}}',
+                'level1.level2': 'we are on the second level'
+            }
+        },
+        zh: {
+            locale: 'zh',
+            locales: {
+                welcome: 'en',
+                hello: 'en',
+                bye: 'en',
+                items: 'en',
+                'level1.level2': 'en',
+                days: 'zh'
+            },
+            translations: {
+                welcome: 'Welcome',
+                hello: 'Hello {name}',
+                bye: 'Bye bye',
+                items: '{count, plural, one{1 Item} other{# Items}}',
+                'level1.level2': 'we are on the second level',
+                days: '{count, plural, other{# 天}}'
+            }
+        }
+    };
+
+    describe('.flatten', done => {
+        it('should return object with flattened keys', done => {
+            expect(Transformer.flatten(translations, 'en', 'en')).to.equal({ en: flattened['en']});
+            done();
+        });
+
+        it('should filter based on the languages needed to resolve translations for given preferred locale', done => {
+            expect(Transformer.flatten(translations, 'fr-CA', 'en')).to.equal({
+                en: flattened['en'],
+                fr: flattened['fr'],
+                'fr-CA': flattened['fr-CA'],
+            });
+            done();
+        });
+    });
+
+    describe('.flatten', done => {
+        it('should return object with cascading translations', done => {
+            expect(Transformer.cascade(flattened, 'en', 'en')).to.equal(cascaded['en']);
+            done();
+        });
+
+        it('should return object based on preferred locale', done => {
+            expect(Transformer.cascade(flattened, 'zh', 'en')).to.equal(cascaded['zh']);
+            done();
+        });
+    });
+
+    describe('.transform', done => {
+        it('transform should do both flatten and cascade', done => {
+            expect(Transformer.transform(translations, 'en', 'en')).to.equal(cascaded['en']);
+            done();
+        });
+    });
+});

--- a/spec/lib/transformer.js
+++ b/spec/lib/transformer.js
@@ -152,12 +152,12 @@ describe('Transformer', () => {
 
     describe('.flatten', done => {
         it('should return object with flattened keys', done => {
-            expect(Transformer.flatten(translations, 'en', 'en')).to.equal({ en: flattened['en']});
+            expect(Transformer.flatten(translations, ['en'])).to.equal({ en: flattened['en']});
             done();
         });
 
         it('should filter based on the languages needed to resolve translations for given preferred locale', done => {
-            expect(Transformer.flatten(translations, 'fr-CA', 'en')).to.equal({
+            expect(Transformer.flatten(translations, ['fr-CA', 'fr', 'en'])).to.equal({
                 en: flattened['en'],
                 fr: flattened['fr'],
                 'fr-CA': flattened['fr-CA'],
@@ -168,19 +168,19 @@ describe('Transformer', () => {
 
     describe('.flatten', done => {
         it('should return object with cascading translations', done => {
-            expect(Transformer.cascade(flattened, 'en', 'en')).to.equal(cascaded['en']);
+            expect(Transformer.cascade(flattened, ['en'])).to.equal(cascaded['en']);
             done();
         });
 
         it('should return object based on preferred locale', done => {
-            expect(Transformer.cascade(flattened, 'zh', 'en')).to.equal(cascaded['zh']);
+            expect(Transformer.cascade(flattened, ['zh', 'en'])).to.equal(cascaded['zh']);
             done();
         });
     });
 
     describe('.transform', done => {
         it('transform should do both flatten and cascade', done => {
-            expect(Transformer.transform(translations, 'en', 'en')).to.equal(cascaded['en']);
+            expect(Transformer.transform(translations, ['en'])).to.equal(cascaded['en']);
             done();
         });
     });

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -5,6 +5,7 @@ const Lab = require('lab');
 const Sinon = require('sinon');
 const Translator = require('../../lib/translator');
 
+const fs = require('fs');
 const lab = exports.lab = Lab.script();
 const beforeEach = lab.beforeEach;
 const describe = lab.experiment;
@@ -340,6 +341,22 @@ describe('Translator', () => {
             };
             const translator = Translator.create('es-mx,de', translations);
             expect(translator.translate('search')).to.equal(translations.en.search);
+            done();
+        });
+    });
+
+    // Lab will output the amount of time spent in this test. We can use it to
+    // compare relative speed of different implementations.
+    it('load test', { timeout: 5000, skip: true }, done => {
+        fs.readFile('./spec/fixtures/lang.json', 'utf8' , (err, translations) => {
+            if (err) {
+                console.error(err);
+                throw err;
+            }
+
+            for (let i = 0; i < 1000; i++) {
+                Translator.create('fr-CA', translations);
+            }
             done();
         });
     });


### PR DESCRIPTION
Improve performance of Transformer

* Note that this PR updates the interface for the functions in `lib/translator/transformer.js` and `lib/translator/locale-parser.js`, but these methods should be considered private to the Translator class so should not constitute a breaking change. The interface for Translator remains the same.
* Use imperative style for Transformer cascade and flatten
* Transformer cascade and flatten now only process the data for the preferred locale, rather than all top level locales. This also changes the return value to a single language, rather than all languages.
* Change LocaleParser.getPreferredLocale to getPreferredLocales (plural) and have it return an ordered list of locales based on the Accept-Language header
* Change Transformer.transform to take a list of preferred locales that also includes the fallback rather than a single locale which would previously lose a lot of information that needed to be reconstructed and led to at least one bug. In addition, we no longer take the fallback locale, but assume that it is already in the preferred locale list.
* Translator.getLocale (which is used by paper-handlebars to inject into the theme context) now returns the primary locale (first in the list of preferred locales). This should be equivalent to before.
* LocaleParser.getLocales has now be made an internal method to the module
* We now automatically inject the regionless language code if not present in the `Accept-Language` header. For example, if `fr-FR` is present in the header, but `fr` is not, and this is a supported language in the theme, we add it immediately after `fr-FR`. We previously were only doing this if there was a single language in the `Accept-Language` header.
* Revert #258 - except for tests, then reimplement on top of the refactor of Transformer.
* Add docs around data structures used in translations
* Add test coverage for transform, flatten, cascade

### Before
For 1,000 instantiations of Translator constructor:

```
[matt.olson@C02X425EJG5M:~/workspace/paper] $ node_modules/.bin/lab -i 18 spec/lib/translator.js


  .

1 tests complete
Test duration: 122376 ms
```

### After
For 1,000 instantiations of Translator constructor:

```
[matt.olson@C02X425EJG5M:~/workspace/paper] $ node_modules/.bin/lab -i 18 spec/lib/translator.js


  .

1 tests complete
Test duration: 5759 ms
```

This is about a 95% improvement.