### PR TITLE
chore: Release 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## Pending
-## 3.0.2 (2022-02-23)
+## 3.0.3 (2022-03-02)
+- STRF-9658 logger accepts strings instead of objects [#270](https://github.com/bigcommerce/paper/pull/270)
+
+# 3.0.2 (2022-02-23)
 - Bumps paper-handlebars to 4.5.3 [#269](https://github.com/bigcommerce/paper/pull/269)
 
 ## 3.0.1 (2022-02-17)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- STRF-9658 logger accepts strings instead of objects [#270](https://github.com/bigcommerce/paper/pull/270)
