### PR TITLE
chore: release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## Pending
-- drop node 12 support  [277](https://github.com/bigcommerce/paper/pull/277)
 
+## 4.0.0 (2022-06-07)
+- bump paper-handlebars: STRF-9835 Reduce proto usage [278](https://github.com/bigcommerce/paper/pull/278)
+- drop node 12 support  [277](https://github.com/bigcommerce/paper/pull/277)
 
 ## 3.0.4 (2022-03-23)
 - bump paper-handlerbars [#275](https://github.com/bigcommerce/paper/pull/275)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "3.0.5",
+  "version": "4.0.0",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "4.5.5",
+    "@bigcommerce/stencil-paper-handlebars": "5.0.0",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
- bump paper-handlebars: STRF-9835 Reduce proto usage [278](https://github.com/bigcommerce/paper/pull/278)
- drop node 12 support  [277](https://github.com/bigcommerce/paper/pull/277)

cc @bigcommece/storefront-team