### PR TITLE
chore: release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pending
 
+## 4.0.1 (2022-06-16)
+- bump paper-handlebars: STRF-9873 use modified implementations of `get`, `getObject`, `moment`, `option` 3p helpers [280](https://github.com/bigcommerce/paper/pull/280)
+
 ## 4.0.0 (2022-06-07)
 - bump paper-handlebars: STRF-9835 Reduce proto usage [278](https://github.com/bigcommerce/paper/pull/278)
 - drop node 12 support  [277](https://github.com/bigcommerce/paper/pull/277)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.0.0",
+    "@bigcommerce/stencil-paper-handlebars": "5.0.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
- bump paper-handlebars: STRF-9873 use modified implementations of `get`, `getObject`, `moment`, `option` 3p helpers [280](https://github.com/bigcommerce/paper/pull/280)
