### PR TITLE
chore: release 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## Pending
+## 4.0.2 (2022-06-27)
+- bump paper-handlebars: Fix replacement `get` and `option` helpers for backwards-compatibility [280](https://github.com/bigcommerce/paper/pull/280)
 
 ## 4.0.1 (2022-06-16)
-- bump paper-handlebars: STRF-9873 use modified implementations of `get`, `getObject`, `moment`, `option` 3p helpers [280](https://github.com/bigcommerce/paper/pull/280)
+- bump paper-handlebars: STRF-9873 use modified implementations of `get`, `getObject`, `moment`, `option` 3p helpers [279](https://github.com/bigcommerce/paper/pull/279)
 
 ## 4.0.0 (2022-06-07)
 - bump paper-handlebars: STRF-9835 Reduce proto usage [278](https://github.com/bigcommerce/paper/pull/278)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.0.1",
+    "@bigcommerce/stencil-paper-handlebars": "5.0.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
- bump paper-handlebars: Fix replacement `get` and `option` helpers for backwards-compatibility [282](https://github.com/bigcommerce/paper/pull/282)
