### PR TITLE
[STRF-9951] expose getter to access renderer's resource hints.

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,6 +272,27 @@ class Paper {
             return result;
         });
     }
+
+    /**
+     * Get resource hints produced by rendering process.
+     * If any helper included in the theme/template/string was
+     * configured to produce a resource hint, then,
+     * AFTER A SUCCESSFUL rendering, this getter may be called.
+     *
+     * Objects in the returned array will contain following properties:
+     * 1. `src: String`
+     * 1. `state: String`
+     *
+     * and MAY contain all or some of the following optional properties:
+     * 1. `type: String`
+     * 1. `cors: String`
+     *
+     * For more details check https://github.com/bigcommerce/paper-handlebars/blob/master/helpers/lib/resourceHints.js
+     * @returns {Object[]}
+     */
+    getResourceHints() {
+        return this.renderer.getResourceHints();
+    }
 }
 
 module.exports = Paper;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.0.6",
+    "@bigcommerce/stencil-paper-handlebars": "5.1.0",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },

--- a/spec/index.js
+++ b/spec/index.js
@@ -90,6 +90,7 @@ describe('render()', function() {
                 'pages/partial': '<p>{{variable}}</p>',
                 'pages/greet': '<h1>{{lang \'good\'}} {{lang \'morning\'}}</h1>',
                 'pages/pre': '{{{pre object}}}',
+                'pages/hints': '{{{ earlyHint themeCss "preload" type="style" }}}'
             }));
         },
         getTranslations: () => {
@@ -99,7 +100,8 @@ describe('render()', function() {
 
     const context = {
         variable: 'hello world',
-        object: {}
+        object: {},
+        themeCss: '/my/asset/style.css'
     };
 
     it('should render pages/product', function(done) {
@@ -120,6 +122,19 @@ describe('render()', function() {
                 done();
             });
         });
+    });
+
+    it('should render pages/hints and find resource hints', done => {
+        const paper = new Paper(null, null, assembler);
+        paper.loadTheme('pages/product', '')
+            .then(() => paper.render('pages/hints', context))
+            .then(result => {
+                expect(result).to.equals(context.themeCss);
+                let hints = paper.getResourceHints();
+                expect(hints).to.have.length(1);
+                expect(hints[0]).to.equals({src: context.themeCss, state: 'preload', type: 'style', cors: 'no'});
+                done();
+            });
     });
 });
 


### PR DESCRIPTION
`Paper` includes a getter of renderer's resource hints.
If any helper included in the theme/template/string was
configured to produce a resource hint, then,
AFTER A SUCCESSFUL rendering, this getter may be called.

For more details check https://github.com/bigcommerce/paper-handlebars/blob/master/helpers/lib/resourceHints.js