### PR TITLE
chore: release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## Pending
+
+## 4.1.0 (2022-08-22)
+- `Paper` exposes a getter to extract renderer' resource hints. ([#285](https://github.com/bigcommerce/paper/pull/285))
+
 ## 4.0.6 (2022-07-14)
 - bump paper-handlebars: bugfix for edge case affecting `get`, `getObject`, and `option` ([#185](https://github.com/bigcommerce/paper-handlebars/pull/185))
 ## 4.0.5 (2022-07-13)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- `Paper` exposes a getter to extract the renderer's resource hints. ([#285](https://github.com/bigcommerce/paper/pull/285))
