### PR TITLE
Release 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pending
 
+## 4.1.1 (2022-08-29)
+- Add a a getter in Paper to access the renderer object. ([#287](https://github.com/bigcommerce/paper/pull/287))
+
 ## 4.1.0 (2022-08-22)
 - `Paper` exposes a getter to extract renderer' resource hints. ([#285](https://github.com/bigcommerce/paper/pull/285))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- Add a a getter in Paper to access the renderer object. ([#287](https://github.com/bigcommerce/paper/pull/287))



@jairo-bc 