### PR TITLE
chore: release 4.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Pending
 
+## 4.1.5 (2022-10-07)
+- Bumps paper-handlebars version ([#294](https://github.com/bigcommerce/paper/pull/294))
+
 ## 4.1.4 (2022-10-06)
 - Bumps paper-handlebars version ([#293](https://github.com/bigcommerce/paper/pull/293))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.1.3",
+    "@bigcommerce/stencil-paper-handlebars": "5.1.4",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
- Bumps paper-handlebars version ([#294](https://github.com/bigcommerce/paper/pull/294))
