### PR TITLE
chore(release): 4.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Pending
+## 4.1.7 (2022-10-17)
 - ref: Bump paper-handlebars version: STRF-10124 clean up hbs helpers ([#297](https://github.com/bigcommerce/paper/pull/297))
 
 ## 4.1.6 (2022-10-13)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
- ref: Bump paper-handlebars version: STRF-10124 clean up hbs helpers ([#297](https://github.com/bigcommerce/paper/pull/297))
