### PR TITLE
fix: STRF-10878 Bump handlebars to 5.7.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.7.7",
+    "@bigcommerce/stencil-paper-handlebars": "5.7.8",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
Need to bump handlebars to 5.7.8 after a small change to the `{{ money }}` helper

@bigcommerce/storefront-team 