### PR TITLE
chore(release): update release to 4.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [4.8.6](https://github.com/bigcommerce/paper/compare/v4.8.5...v4.8.6) (2023-06-15)
+
+
+### Bug Fixes
+
+* STRF-10878 Bump handlebars to 5.7.8 ([#341](https://github.com/bigcommerce/paper/issues/341)) ([e2142ab](https://github.com/bigcommerce/paper/commit/e2142ab852d5a568f39c3d52f0c70b12e1c70c5d))
+
+
 ## [4.8.5](https://github.com/bigcommerce/paper/compare/v4.8.4...v4.8.5) (2023-05-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigcommerce/stencil-paper",
-  "version": "4.8.5",
+  "version": "4.8.6",
   "description": "A Stencil plugin to load template files and render pages using backend renderer plugins.",
   "main": "index.js",
   "author": "Bigcommerce",


### PR DESCRIPTION
Need to manually update release/changelog to 4.8.6, as my previous PR didn't make the chore PR.

@bigcommerce/storefront-team 