### PR TITLE
feat(merc): Bump paper handlebars - webdav cache control

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.7.8",
+    "@bigcommerce/stencil-paper-handlebars": "5.9.0",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
- [x] [Paper Handlebars](https://github.com/bigcommerce/paper-handlebars/pull/273)
- [ ] [Paper](https://github.com/bigcommerce/paper/pull/343) (bump version)
- [ ] Stencil Cli (bump version)
- [ ] Storefront Renderer (bump verion) 

## What? Why?
Use CDN Original images for webdav - cache control. 

If a developer/merchant decide to use the handlebar to import images from WebDav into the theme `({{cdn "webdav:/img/image.jpg"}})`, there is no cache-control header when the image is presented to the storefront.

Similar to our Image Manager, we should be using the cdn original images (Similar to Jinsoo's PR here [MERC-7127](https://github.com/bigcommerce/bigcommerce/pull/47254)


## How was it tested?
Tested locally

cc @bigcommerce/storefront-team


[MERC-7127]: https://bigcommercecloud.atlassian.net/browse/MERC-7127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ