### PR TITLE
fix: semantic release auto-PR creation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## What? Why?
+
+## How was it tested?
+
+----
+
+cc @bigcommerce/storefront-team

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.9.0",
+    "@bigcommerce/stencil-paper-handlebars": "5.9.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },
@@ -43,7 +43,7 @@
     "husky": "^8.0.1",
     "lab": "~13.0.1",
     "semantic-release": "^19.0.5",
-    "semantic-release-github-pullrequest": "^1.3.0",
+    "semantic-release-github-pullrequest": "https://github.com/jairo-bc/semantic-release-github-pullrequest",
     "sinon": "~7.5.0"
   }
 }


### PR DESCRIPTION
## What? Why?

Bumping versions to fix semantic release PR creation.
Added github PR template.

## How was it tested?

in paper-handlerbars

----

cc @bigcommerce/storefront-team
