### PR TITLE
fix(merc): MERC-9364 bump paper handlebars - revert CDN Webdav Url

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.9.2",
+    "@bigcommerce/stencil-paper-handlebars": "5.9.3",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?
Reverts `paper-handlebars` Webdav CDN Url

fix(merc): MERC-9364 bump paper handlebars - revert CDN Webdav Url

cc @bigcommerce/storefront-team
