### PR TITLE
fix: bump paper hbs with chrono updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.9.3",
+    "@bigcommerce/stencil-paper-handlebars": "5.9.4",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

bump paper hbs version

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
