### PR TITLE
fix: bump paper handlebars to 5.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "5.9.4",
+    "@bigcommerce/stencil-paper-handlebars": "5.9.5",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

bump paper handlebars with handlebars v4 update

## How was it tested?

- cdvm
- npm test

----

cc @bigcommerce/storefront-team
