### PR TITLE
fix: bump paper handlebars to 5.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "^5.10.1",
+    "@bigcommerce/stencil-paper-handlebars": "^5.10.3",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

Bump paper handlebars

## How was it tested?
Tested with paper handlebars PRs

----

cc @bigcommerce/storefront-team
