### PR TITLE
fix: bump paper handlebars to 5.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "^5.10.3",
+    "@bigcommerce/stencil-paper-handlebars": "^5.10.4",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

Bump paper handlebars to remove quotes from nonce handlebars helper - https://github.com/bigcommerce/paper-handlebars/pull/309

## How was it tested?

1. Pull PR locally
2. Within directory use `npm link`
3. Inside storefront-renderer-2 run `npm link @bigcommerce/stencil-paper`
4. Run storefront-renderer-2 locally and turn on STRF-11672.Enable_nonce_csp_header
5. Add to script manager
```
<script>
    {{nonce}}
</script>
```
7. See that nonce is shown without outer quotes, and is also displayed in attributes section of the script tag

[STRF-11672.Enable_nonce_csp_header](https://app.launchdarkly.com/default/development/features/STRF-11672.Enable_nonce_csp_header) on

![Screenshot 2024-06-11 at 11 55 44 AM](https://github.com/bigcommerce/paper/assets/5630999/3090a201-fdb2-44ac-be14-4a96a966c3a2)

[STRF-11672.Enable_nonce_csp_header](https://app.launchdarkly.com/default/development/features/STRF-11672.Enable_nonce_csp_header) off 

![Screenshot 2024-06-11 at 11 56 19 AM](https://github.com/bigcommerce/paper/assets/5630999/abf09332-ece9-4b40-b535-e08f7ad9a493)

8. Ongoing work with Merc, some errors will be expected with STRF-11672.Enable_nonce_csp_header on
----

cc @bigcommerce/storefront-team
