### PR TITLE
fix(storefront): STRF-12281 Bump paper-handlebars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "^5.10.4",
+    "@bigcommerce/stencil-paper-handlebars": "^5.11.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
### Jira: [STRF-12281](https://bigcommercecloud.atlassian.net/browse/STRF-12281)

## What/Why?
Bump paper-handlebars version to latest.

## Rollout/Rollback
Roll back this PR

## Testing
n/a

----

cc @bigcommerce/team-storefront 


[STRF-12281]: https://bigcommercecloud.atlassian.net/browse/STRF-12281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ