### PR TITLE
fix: STRF-12276 bump paper hbs with compiler fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "^5.11.1",
+    "@bigcommerce/stencil-paper-handlebars": "^5.11.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

Bump paper-handlebars https://github.com/bigcommerce/paper-handlebars/pull/320

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
