### PR TITLE
fix: STRF-12234 bump paper-handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.0.0",
+    "@bigcommerce/stencil-paper-handlebars": "6.0.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

bump paper-handlebars with https://github.com/bigcommerce/paper-handlebars/pull/331


----

cc @bigcommerce/team-storefront
