### PR TITLE
fix: bump paper handlebars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.0.1",
+    "@bigcommerce/stencil-paper-handlebars": "6.0.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.2.2"
   },


### PR DESCRIPTION
## What? Why?

More https://github.com/bigcommerce/paper-handlebars/pull/333

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
