### PR TITLE
fix(storefront): STRF-12688 Update messageformat dependency

### DIFF
--- a/lib/translator/index.js
+++ b/lib/translator/index.js
@@ -162,7 +162,7 @@ Translator.prototype._compileTemplate = function (key) {
     try {
         return formatter.compile(this._language.translations[key]);
     } catch (err) {
-        if (err.name === 'SyntaxError') {
+        if (err.name === 'Error') {
             this._logger.warn(`Language File Syntax Error: ${err.message} for key "${key}"`, err.expected);
             return () => '';
         }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint-and-fix": "eslint . --fix",
-    "test": "lab -v -t 95 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,FinalizationRegistry,WeakRef,plural,en,number,select,__extends,__assign,__rest,__decorate,__param,__esDecorate,__runInitializers,__propKey,__setFunctionName,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn,AggregateError,BroadcastChannel,structuredClone,DOMException,AbortController,AbortSignal,EventTarget,Event,MessageChannel,MessagePort,MessageEvent,atob,btoa,Blob,Performance,performance,ReadableStream,ReadableStreamDefaultReader,ReadableStreamBYOBReader,ReadableStreamBYOBRequest,ReadableByteStreamController,ReadableStreamDefaultController,TransformStream,TransformStreamDefaultController,WritableStream,WritableStreamDefaultWriter,WritableStreamDefaultController,ByteLengthQueuingStrategy,CountQueuingStrategy,TextEncoderStream,TextDecoderStream,CompressionStream,DecompressionStream,fetch,FormData,Headers,Request,Response,__addDisposableResource,__disposeResources,File,PerformanceEntry,PerformanceMark,PerformanceMeasure,PerformanceObserver,PerformanceObserverEntryList,PerformanceResourceTiming,WebSocket,Iterator,Navigator,navigator,crypto,Crypto,CryptoKey,SubtleCrypto,CustomEvent spec",
+    "test": "lab -v -t 94 --ignore i18n,WebAssembly,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt,URL,URLSearchParams,TextEncoder,TextDecoder,queueMicrotask,FinalizationRegistry,WeakRef,plural,en,number,select,__extends,__assign,__rest,__decorate,__param,__esDecorate,__runInitializers,__propKey,__setFunctionName,__metadata,__awaiter,__generator,__exportStar,__createBinding,__values,__read,__spread,__spreadArrays,__spreadArray,__await,__asyncGenerator,__asyncDelegator,__asyncValues,__makeTemplateObject,__importStar,__importDefault,__classPrivateFieldGet,__classPrivateFieldSet,__classPrivateFieldIn,__rewriteRelativeImportExtension,AggregateError,BroadcastChannel,structuredClone,DOMException,AbortController,AbortSignal,EventTarget,Event,MessageChannel,MessagePort,MessageEvent,atob,btoa,Blob,Performance,performance,ReadableStream,ReadableStreamDefaultReader,ReadableStreamBYOBReader,ReadableStreamBYOBRequest,ReadableByteStreamController,ReadableStreamDefaultController,TransformStream,TransformStreamDefaultController,WritableStream,WritableStreamDefaultWriter,WritableStreamDefaultController,ByteLengthQueuingStrategy,CountQueuingStrategy,TextEncoderStream,TextDecoderStream,CompressionStream,DecompressionStream,fetch,FormData,Headers,Request,Response,__addDisposableResource,__disposeResources,File,PerformanceEntry,PerformanceMark,PerformanceMeasure,PerformanceObserver,PerformanceObserverEntryList,PerformanceResourceTiming,WebSocket,Iterator,Navigator,navigator,crypto,Crypto,CryptoKey,SubtleCrypto,CustomEvent spec",
     "coverage": "lab -c -r console -o stdout -r html -o coverage.html spec",
     "release": "semantic-release"
   },
@@ -27,7 +27,7 @@
   "dependencies": {
     "@bigcommerce/stencil-paper-handlebars": "6.0.2",
     "accept-language-parser": "~1.4.1",
-    "messageformat": "~0.2.2"
+    "messageformat": "~0.3.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.4.0",

--- a/spec/lib/translator.js
+++ b/spec/lib/translator.js
@@ -132,7 +132,7 @@ describe('Translator', () => {
 
         expect(translator.translate('hello')).to.equal('');
         expect(loggerStub.warn.called).to.equal(true);
-        expect(loggerStub.warn.getCall(0).args[0]).to.equal("MessageFormat: Data required for 'name'.")
+        expect(loggerStub.warn.getCall(0).args[0]).to.equal("Cannot read properties of undefined (reading 'name')")
 
         done();
     });
@@ -145,7 +145,7 @@ describe('Translator', () => {
         }, loggerStub);
 
         const result = translator.translate('items_with_syntax_error', { count: 1 });
-        const errMessage = 'Language File Syntax Error: Expected "plural" or "select" but "p" found. for key "items_with_syntax_error"';
+        const errMessage = 'Language File Syntax Error: Parser error: SyntaxError: Expected "," or "}" but "{" found. for key "items_with_syntax_error"';
         expect(result).to.equal("");
         expect(loggerStub.warn.called).to.equal(true);
         expect(loggerStub.warn.getCall(0).args[0]).to.equal(errMessage);
@@ -158,9 +158,14 @@ describe('Translator', () => {
             en: {
                 gender_error: '{gender, select, male{He} female{She}} liked this.',
             },
-        });
+        }, loggerStub);
 
-        expect(() => translator.translate('gender_error', { gender: 'asdf' })).to.throw(Error);
+        const result = translator.translate('gender_error', { gender: 'asdf' });
+
+        const errMessage = 'Language File Syntax Error: Precompiler error: Error: No \'other\' form found in selectFormatPattern 0 for key "gender_error"';
+        expect(result).to.equal("");
+        expect(loggerStub.warn.called).to.equal(true);
+        expect(loggerStub.warn.getCall(0).args[0]).to.equal(errMessage);
 
         done();
     });


### PR DESCRIPTION
## What? Why?

The previous version of messageformat (which is quite old) uses underscore which has a security vulnerability

https://github.com/bigcommerce/storefront-renderer-2/security/dependabot/4

This updates to the closest version which doesnt not have underscore

## How was it tested?

Tested locally

Before:
<img width="905" alt="Screenshot 2024-12-13 at 9 39 59 AM" src="https://github.com/user-attachments/assets/dbb1ceb0-3f13-47aa-9f36-86ac59195909" />

After:
<img width="882" alt="Screenshot 2024-12-13 at 9 39 37 AM" src="https://github.com/user-attachments/assets/2293974f-173b-43c5-9141-3b3a0acbd978" />



----

cc @bigcommerce/storefront-team
