### PR TITLE
fix: add new paper handlebars version for webdav cache control

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const Translator = require('./lib/translator');
-const HandlebarsRenderer = require('@bigcommerce/stencil-paper-handlebars');
+const HandlebarsRendererOriginal = require('@bigcommerce/stencil-paper-handlebars');
+const HandlebarsRendererV2 = require('@bigcommerce/stencil-paper-handlebars-v2');
 
 /**
 * processor is an optional function to apply during template assembly. The
@@ -45,9 +46,12 @@ class Paper {
     * @param {Object} logger - a console-like logger object
     * @param {String} logLevel - log level used by handlebars logger (debug, info, warning, error)
     * @param {Object} params - Request-level parameters, part of stencil context 
+    * @param {Boolean} useNewPaperLibrary - Flag for switching between Handlebars Renderer versions
     */
-    constructor(siteSettings, themeSettings, assembler, rendererType, logger = console, logLevel = 'info', params = {}) {
+    constructor(siteSettings, themeSettings, assembler, rendererType, logger = console, logLevel = 'info', params = {}, useNewPaperLibrary = false) {
         this._assembler = assembler || {};
+
+        const HandlebarsRenderer = useNewPaperLibrary ? HandlebarsRendererV2 : HandlebarsRendererOriginal;
 
         // Build renderer based on type
         switch(rendererType) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
     "@bigcommerce/stencil-paper-handlebars": "6.2.4",
+    "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
## What? Why?
This PR adds a new version of `paper-handlebars` for adding webdav cache-control.  HandlebarsRenderer is chosen based on experiment `SD-9364.Use_cdn_original_content_for_webdav_images`.

Based on https://github.com/bigcommerce/paper-handlebars/pull/298

## How was it tested?
tested locally via postman
 results can be seen [here](https://github.com/bigcommerce/storefront-renderer-2/pull/118)


----

cc @bigcommerce/storefront-team
