### PR TITLE
fix: bump paper hbs to 6.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.0.3",
+    "@bigcommerce/stencil-paper-handlebars": "6.0.4",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
## What? Why?

more here: https://github.com/bigcommerce/paper-handlebars/pull/347

## How was it tested?

npm test 

----

cc @bigcommerce/storefront-team
