### PR TITLE
fix: release 6.2.2 hbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.2.1",
+    "@bigcommerce/stencil-paper-handlebars": "6.2.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
## What? Why?

release hbs bump to 6.2.2

## How was it tested?

npm test 

----

cc @bigcommerce/storefront-team
