### PR TITLE
fix: bump paper hbs to 6.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.3.1",
+    "@bigcommerce/stencil-paper-handlebars": "6.3.2",
     "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"


### PR DESCRIPTION
## What? Why?

bump paper-handlebars 6.3.2

## How was it tested?

npm test

----

cc @bigcommerce/storefront-team
