### PR TITLE
feat: bump paper handlebars to v6.4.1 and remove handlebars-v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const Translator = require('./lib/translator');
-const HandlebarsRendererOriginal = require('@bigcommerce/stencil-paper-handlebars');
-const HandlebarsRendererV2 = require('@bigcommerce/stencil-paper-handlebars-v2');
+const HandlebarsRenderer = require('@bigcommerce/stencil-paper-handlebars');
 
 /**
 * processor is an optional function to apply during template assembly. The
@@ -46,12 +45,9 @@ class Paper {
     * @param {Object} logger - a console-like logger object
     * @param {String} logLevel - log level used by handlebars logger (debug, info, warning, error)
     * @param {Object} params - Request-level parameters, part of stencil context 
-    * @param {Boolean} useNewPaperLibrary - Flag for switching between Handlebars Renderer versions
     */
-    constructor(siteSettings, themeSettings, assembler, rendererType, logger = console, logLevel = 'info', params = {}, useNewPaperLibrary = false) {
+    constructor(siteSettings, themeSettings, assembler, rendererType, logger = console, logLevel = 'info', params = {}) {
         this._assembler = assembler || {};
-
-        const HandlebarsRenderer = useNewPaperLibrary ? HandlebarsRendererV2 : HandlebarsRendererOriginal;
 
         // Build renderer based on type
         switch(rendererType) {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.4.0",
-    "@bigcommerce/stencil-paper-handlebars-v2": "git+ssh://git@github.com/bigcommerce/paper-handlebars.git#MERC-9364",
+    "@bigcommerce/stencil-paper-handlebars": "6.4.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
## What? Why?

This PR bumps a version of paper-handlebars to v6.4.1  and remove handlebars-v2 introduced in [PR#400](https://github.com/bigcommerce/paper/pull/400). 

It's part of cleanup for Experiment `SD-9364.Use_cdn_original_content_for_webdav_images`

## How was it tested?
tested locally

cc @bigcommerce/storefront-team
