### PR TITLE
fix(deps): bump @bigcommerce/stencil-paper-handlebars to 6.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.4.1",
+    "@bigcommerce/stencil-paper-handlebars": "6.5.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
Jira: [TRAC-308](https://bigcommercecloud.atlassian.net/browse/TRAC-308)

## What/Why?
Bump `@bigcommerce/stencil-paper-handlebars` from `6.4.1` to `6.5.1` to pick up the `@bigcommerce/handlebars-v4` `4.8.1` update.

Depends on: bigcommerce/paper-handlebars#397

## Rollout/Rollback
Standard npm package bump. Rollback by reverting this PR and releasing a new version.

## Testing
Existing test suite covers rendering behavior.

[TRAC-308]: https://bigcommercecloud.atlassian.net/browse/TRAC-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ