### PR TITLE
chore(release): update paper-handlebars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.5.1",
+    "@bigcommerce/stencil-paper-handlebars": "6.6.1",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
## What? Why?
Updating paper-handlebars.
https://github.com/bigcommerce/paper-handlebars/pull/402

## How was it tested?
Added unit tests.

----

cc @bigcommerce/storefront-team
