### PR TITLE
fix(deps): bump @bigcommerce/stencil-paper-handlebars to 6.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.6.1",
+    "@bigcommerce/stencil-paper-handlebars": "6.6.2",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
Jira: [TRAC-875](https://bigcommercecloud.atlassian.net/browse/TRAC-875)

## What? Why?

- Bump `@bigcommerce/stencil-paper-handlebars` 6.6.1 → 6.6.2
- Picks up bigcommerce/paper-handlebars#404: preserves a helper `ValidationError`'s type through `render()`/`renderString()` instead of wrapping it as `RenderError`
- Needed so downstream consumers (storefront-renderer-2) can classify helper input-validation errors (e.g. `assignVar` rejecting values >1024 chars) as a 4xx instead of a 500 — this also fixes the dual-package-hazard where `paper`'s own bundled renderer previously threw a `RenderError` that couldn't be distinguished from validation failures
- Part of a multi-repo change (paper-handlebars → paper → storefront-renderer-2 → storefront)

## How was it tested?

- Full suite passes (41/41, 1 pre-existing skip)
- Confirmed installed package contains the fix (`ValidationError` preserved, not wrapped)

[TRAC-875]: https://bigcommercecloud.atlassian.net/browse/TRAC-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ