### PR TITLE
fix(ci): remove npm@latest upgrade in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '22.x'
-      - run: npm i -g npm@latest
       - run: npm i
       - name: Check Git Commit name
         run: git log -1 --pretty=format:"%s" |  npx commitlint


### PR DESCRIPTION
## What? Why?

- Release workflow ran `npm i -g npm@latest` before install, picking up whatever npm CLI is newest each run
- A recent npm release added a new default restriction (`EALLOWGIT`) blocking git-protocol dependencies
- This repo's `semantic-release-github-pullrequest` devDependency points at a git fork — install now fails, blocking every release since (including the 6.6.2 dependency bump in #433)
- No `engines.npm` pin — just drop the forced upgrade, let `actions/setup-node`'s bundled npm run install
- Same root cause + same fix as bigcommerce/paper-handlebars#405 (merged, confirmed working)

## How was it tested?

- Commit message passes commitlint locally
- Fix already validated in paper-handlebars (same workflow pattern, same failure, same one-line fix)