### PR TITLE
fix(deps): bump @bigcommerce/stencil-paper-handlebars to 6.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/bigcommerce/paper",
   "dependencies": {
-    "@bigcommerce/stencil-paper-handlebars": "6.6.2",
+    "@bigcommerce/stencil-paper-handlebars": "6.6.3",
     "accept-language-parser": "~1.4.1",
     "messageformat": "~0.3.1"
   },


### PR DESCRIPTION
Jira: [TRAC-961](https://bigcommercecloud.atlassian.net/browse/TRAC-961) (LTRAC-993)

## What/Why?

- Bump `@bigcommerce/stencil-paper-handlebars` 6.6.2 → 6.6.3. That release swapped its `@bigcommerce/handlebars-v4` wrapper dep for an npm alias, so this removes the wrapper from `@bigcommerce/stencil-paper`'s transitive tree — part of deprecating `@bigcommerce/handlebars-v4`.
- No source changes; transitive dep-tree only.

## Rollout/Rollback

- Dependency bump only. Rollback = revert this PR.

## Testing

- `npm test` — passes on node 22 (coverage 95.63% > 94 threshold).
- Verified `@bigcommerce/handlebars-v4` no longer resolves in the tree; `stencil-paper-handlebars@6.6.3` installed.

[TRAC-961]: https://bigcommercecloud.atlassian.net/browse/TRAC-961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ